### PR TITLE
Resolve Issue 78 : DropdownItem Click Event Parameter Type Issue

### DIFF
--- a/SiemensIXBlazor.Tests/Dropdown/DropdownItemTest.cs
+++ b/SiemensIXBlazor.Tests/Dropdown/DropdownItemTest.cs
@@ -35,10 +35,10 @@ public class DropdownItemTest : TestContextBase
 
         var cut = RenderComponent<DropdownItem>(parameters => parameters
             .Add(p => p.OnClickEvent,
-                EventCallback.Factory.Create<string>(this, label => isOnClickEventTriggered = true)));
+                EventCallback.Factory.Create<DropdownItem>(this, label => isOnClickEventTriggered = true)));
 
         // Act
-        await cut.Instance.OnClickEvent.InvokeAsync("testLabel");
+        await cut.Instance.OnClickEvent.InvokeAsync(cut.Instance);
 
         // Assert
         Assert.True(isOnClickEventTriggered);

--- a/SiemensIXBlazor/Components/Dropdown/DropdownItem.razor
+++ b/SiemensIXBlazor/Components/Dropdown/DropdownItem.razor
@@ -16,5 +16,5 @@ style="@Style"
 class="@Class"
 label="@Label" 
 value="@Value" 
-@onclick="() => Clicked(Label)">
+@onclick="() => Clicked(this)">
 </ix-dropdown-item>

--- a/SiemensIXBlazor/Components/Dropdown/DropdownItem.razor.cs
+++ b/SiemensIXBlazor/Components/Dropdown/DropdownItem.razor.cs
@@ -18,11 +18,11 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string Value { get; set; } = string.Empty;
         [Parameter]
-        public EventCallback<string> OnClickEvent { get; set; }
+        public EventCallback<DropdownItem> OnClickEvent { get; set; }
 
-        private async void Clicked(string label)
+        private async void Clicked(DropdownItem dropdownItem)
         {
-            await OnClickEvent.InvokeAsync(label);
+            await OnClickEvent.InvokeAsync(dropdownItem);
         }
     }
 }


### PR DESCRIPTION
Change dropdown item to return the component instead of just the label to better match the ix core library functionality

<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
Currently, the Dropdown Item component OnClickEvent returns the label string property and does not match the current IX Core functionality
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #78 

## 🆕 What is the new behavior?
With the changes, the Dropdown Item component OnClickEvent returns the DropdownItem component itself allowing access to more properties and matches the functionality of the IX Core.
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
