### PR TITLE
Fix Path to interops does not match PackageId => Siemens.IX.Blazor

### DIFF
--- a/SiemensIXBlazor/Interops/BaseInterop.cs
+++ b/SiemensIXBlazor/Interops/BaseInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public BaseInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/baseJsInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/baseJsInterop.js").AsTask());
         }
 
         public async Task AddEventListener(object classObject, string id, string eventName, string callbackFunctionName)

--- a/SiemensIXBlazor/Interops/FileUploadInterop.cs
+++ b/SiemensIXBlazor/Interops/FileUploadInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public FileUploadInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/fileUploadInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/fileUploadInterop.js").AsTask());
         }
 
         public async Task AddEventListener(object classObject, string id, string eventName, string callbackFunctionName)

--- a/SiemensIXBlazor/Interops/TabsInterop.cs
+++ b/SiemensIXBlazor/Interops/TabsInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public TabsInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/tabsInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/tabsInterop.js").AsTask());
         }
 
         public async Task InitialComponent(string id)


### PR DESCRIPTION

## 💡 What is the current behavior?

Does not work at runtime, because it can't find the js files loaded by the interops.


## 🆕 What is the new behavior?

Fixed path to new PackageId

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated
- [ ] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x ] 🏗️ Successful compilation (`dotnet build`, changes pushed)


