### PR TITLE
fix interop path to new PackageId.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Add required `CSS` and `Javascript` packages into the `index.html` file.
     <!--Deprecated after v0.4.0-->
     <link
       rel="stylesheet"
-      href="_content/SiemensIXBlazor/css/siemens-ix/ix-icons.css"
+      href="_content/Siemens.IX.Blazor/css/siemens-ix/ix-icons.css"
     />
 
     <link
       rel="stylesheet"
-      href="_content/SiemensIXBlazor/css/siemens-ix/siemens-ix.css"
+      href="_content/Siemens.IX.Blazor/css/siemens-ix/siemens-ix.css"
     />
   </head>
   <body>
     ...
-    <script src="_content/SiemensIXBlazor/js/siemens-ix/index.bundle.js"></script>
+    <script src="_content/Siemens.IX.Blazor/js/siemens-ix/index.bundle.js"></script>
   </body>
 </html>
 ```

--- a/SiemensIXBlazor/Components/About/AboutMenu.razor.cs
+++ b/SiemensIXBlazor/Components/About/AboutMenu.razor.cs
@@ -54,7 +54,7 @@ namespace SiemensIXBlazor.Components.About
                 await _interop.AddEventListener(this, Id, "close", "Closed");
 
                 moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "./_content/SiemensIXBlazor/js/interops/aboutMenuInterop.js").AsTask());
+                "import", "./_content/Siemens.IX.Blazor/js/interops/aboutMenuInterop.js").AsTask());
             }
         }
 

--- a/SiemensIXBlazor/Components/Application/Application.razor.cs
+++ b/SiemensIXBlazor/Components/Application/Application.razor.cs
@@ -49,7 +49,7 @@ public partial class Application
     {
 
         moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", $"./_content/SiemensIXBlazor/js/interops/applicationInterop.js").AsTask());
+            "import", $"./_content/Siemens.IX.Blazor/js/interops/applicationInterop.js").AsTask());
 
         Task.Run(async () =>
         {

--- a/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
+++ b/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
@@ -115,7 +115,7 @@ namespace SiemensIXBlazor.Components.CategoryFilter
         {
 
             moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/categoryFilterInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/categoryFilterInterop.js").AsTask());
 
             Task.Run(async () =>
             {

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
@@ -67,7 +67,7 @@ public partial class DateDropdown
     private async Task InitialParameterAsync(string functionName, object? param)
     {
         _moduleTask = new Lazy<Task<IJSObjectReference>>(() => JsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/SiemensIXBlazor/js/interops/dateDropdownInterop.js").AsTask());
+            "import", "./_content/Siemens.IX.Blazor/js/interops/dateDropdownInterop.js").AsTask());
 
         var dateRangeOptions = JsonConvert.SerializeObject(param, new JsonSerializerSettings
         {

--- a/SiemensIXBlazor/Components/MenuSettings/MenuSettings.razor.cs
+++ b/SiemensIXBlazor/Components/MenuSettings/MenuSettings.razor.cs
@@ -41,7 +41,7 @@ namespace SiemensIXBlazor.Components.MenuSettings
                 await _interop.AddEventListener(this, Id, "close", "Closed");
 
                 moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "./_content/SiemensIXBlazor/js/interops/settingsMenuInterop.js").AsTask());
+                "import", "./_content/Siemens.IX.Blazor/js/interops/settingsMenuInterop.js").AsTask());
             }
         }
 

--- a/SiemensIXBlazor/Components/Tree/Tree.razor.cs
+++ b/SiemensIXBlazor/Components/Tree/Tree.razor.cs
@@ -75,7 +75,7 @@ namespace SiemensIXBlazor.Components.Tree
         {
 
             moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/treeInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/treeInterop.js").AsTask());
 
             Task.Run(async () =>
             {

--- a/SiemensIXBlazor/Interops/BaseInterop.cs
+++ b/SiemensIXBlazor/Interops/BaseInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public BaseInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/baseJsInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/baseJsInterop.js").AsTask());
         }
 
         public async Task AddEventListener(object classObject, string id, string eventName, string callbackFunctionName)

--- a/SiemensIXBlazor/Interops/FileUploadInterop.cs
+++ b/SiemensIXBlazor/Interops/FileUploadInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public FileUploadInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/fileUploadInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/fileUploadInterop.js").AsTask());
         }
 
         public async Task AddEventListener(object classObject, string id, string eventName, string callbackFunctionName)

--- a/SiemensIXBlazor/Interops/TabsInterop.cs
+++ b/SiemensIXBlazor/Interops/TabsInterop.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Interops
         public TabsInterop(IJSRuntime jsRuntime)
         {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/SiemensIXBlazor/js/interops/tabsInterop.js").AsTask());
+                "import", $"./_content/Siemens.IX.Blazor/js/interops/tabsInterop.js").AsTask());
         }
 
         public async Task InitialComponent(string id)


### PR DESCRIPTION

## 🆕 What is the new behavior?

Aligned path in interpose to new PackageId.
## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated
- [ ] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

