### PR TITLE
Update version diffs

### DIFF
--- a/SiemensIXBlazor.Tests/CardListTests.cs
+++ b/SiemensIXBlazor.Tests/CardListTests.cs
@@ -13,67 +13,70 @@ using SiemensIXBlazor.Components;
 
 namespace SiemensIXBlazor.Tests
 {
-    public class CardListTests: TestContextBase
-    {
-        [Fact]
-        public void CardListRendersWithoutCrashing()
-        {
-            // Arrange
-            var cut = RenderComponent<CardList>(parameters => {
-                parameters.Add(p => p.Id, "testId");
-                parameters.Add(p => p.Collapse, true);
-                parameters.Add(p => p.I18NMoreCards, "testMoreCards");
-                parameters.Add(p => p.I18NShowAll, "testShowAll");
-                parameters.Add(p => p.Label, "testLabel");
-                parameters.Add(p => p.ListStyle, Enums.CardList.CardListStyle.Stack);
-                parameters.Add(p => p.ShowAllCount, 1);
-                parameters.Add(p => p.SuppressOverflowHandling, true);
-            });
+	public class CardListTests : TestContextBase
+	{
+		[Fact]
+		public void CardListRendersWithoutCrashing()
+		{
+			// Arrange
+			var cut = RenderComponent<CardList>(parameters =>
+			{
+				parameters.Add(p => p.Id, "testId");
+				parameters.Add(p => p.Collapse, true);
+				parameters.Add(p => p.I18NMoreCards, "testMoreCards");
+				parameters.Add(p => p.I18NShowAll, "testShowAll");
+				parameters.Add(p => p.Label, "testLabel");
+				parameters.Add(p => p.ListStyle, Enums.CardList.CardListStyle.Stack);
+				parameters.Add(p => p.ShowAllCount, 1);
+				parameters.Add(p => p.SuppressOverflowHandling, true);
+				parameters.Add(p => p.HideShowAll, true);
 
-            // Assert
-            cut.MarkupMatches("<ix-card-list id=\"testId\" label=\"testLabel\" show-all-count=\"1\" list-style=\"stack\" collapse=\"\" i-1-8n-more-cards=\"testMoreCards\" i-1-8n-show-all=\"testShowAll\" suppress-overflow-handling=\"\"></ix-card-list>");
-        }
+			});
 
-        [Fact]
-        public void CollapsedChangedEventTriggeredCorrectly()
-        {
-            // Arrange
-            var eventTriggered = false;
-            var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.CollapseChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
+			// Assert
+			cut.MarkupMatches("<ix-card-list id=\"testId\" label=\"testLabel\" show-all-count=\"1\" list-style=\"stack\" collapse=\"\" i-1-8n-more-cards=\"testMoreCards\" i-1-8n-show-all=\"testShowAll\" suppress-overflow-handling=\"\" hide-show-all></ix-card-list>");
+		}
 
-            // Act
-            cut.Instance.CollapseChangedEvent.InvokeAsync(true);
+		[Fact]
+		public void CollapsedChangedEventTriggeredCorrectly()
+		{
+			// Arrange
+			var eventTriggered = false;
+			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.CollapseChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
 
-            // Assert
-            Assert.True(eventTriggered);
-        }
+			// Act
+			cut.Instance.CollapseChangedEvent.InvokeAsync(true);
 
-        [Fact]
-        public void ShowAllClickedEventTriggeredCorrectly()
-        {
-            // Arrange
-            var eventTriggered = false;
-            var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowAllClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+			// Assert
+			Assert.True(eventTriggered);
+		}
 
-            // Act
-            cut.Instance.ShowAllClickEvent.InvokeAsync();
+		[Fact]
+		public void ShowAllClickedEventTriggeredCorrectly()
+		{
+			// Arrange
+			var eventTriggered = false;
+			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowAllClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
-            // Assert
-            Assert.True(eventTriggered);
-        }
+			// Act
+			cut.Instance.ShowAllClickEvent.InvokeAsync();
 
-        [Fact]
-        public void ShowMoreCardClickedEventTriggeredCorrectly()
-        {
-            // Arrange
-            var eventTriggered = false;
-            var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowMoreCardClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+			// Assert
+			Assert.True(eventTriggered);
+		}
 
-            // Act
-            cut.Instance.ShowMoreCardClickEvent.InvokeAsync();
+		[Fact]
+		public void ShowMoreCardClickedEventTriggeredCorrectly()
+		{
+			// Arrange
+			var eventTriggered = false;
+			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowMoreCardClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
-            // Assert
-            Assert.True(eventTriggered);
-        }
-    }
+			// Act
+			cut.Instance.ShowMoreCardClickEvent.InvokeAsync();
+
+			// Assert
+			Assert.True(eventTriggered);
+		}
+	}
 }

--- a/SiemensIXBlazor.Tests/CategoryFilterTests.cs
+++ b/SiemensIXBlazor.Tests/CategoryFilterTests.cs
@@ -30,10 +30,12 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.Placeholder, "TestPlaceholder");
                 parameters.Add(p => p.RepeatCategories, true);
                 parameters.Add(p => p.Suggestions, ["testSugestion"]);
+                parameters.Add(p => p.Disabled, true);
+                parameters.Add(p => p.Readonly, true);
             });
 
             // Assert
-            cut.MarkupMatches("<ix-category-filter id=\"testId\" placeholder=\"TestPlaceholder\" hide-icon=\"\" i-1-8n-plain-text=\"testI18PlainText\" icon=\"testIcon\" label-categories=\"testLabelCategories\" repeat-categories=\"\"></ix-category-filter>");
+            cut.MarkupMatches("<ix-category-filter id=\"testId\" placeholder=\"TestPlaceholder\" hide-icon=\"\" i-1-8n-plain-text=\"testI18PlainText\" icon=\"testIcon\" label-categories=\"testLabelCategories\" repeat-categories=\"\" readonly disabled></ix-category-filter>");
         }
 
         [Fact]

--- a/SiemensIXBlazor.Tests/DateDropdownTest.cs
+++ b/SiemensIXBlazor.Tests/DateDropdownTest.cs
@@ -7,96 +7,99 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using System.Text.Json;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Components.BasicNavigation;
+using SiemensIXBlazor.Enums.BasicNavigation;
 using SiemensIXBlazor.Objects.DateDropdown;
+using System.Text.Json;
 
 namespace SiemensIXBlazor.Tests;
 
 public class DateDropdownTest : TestContextBase
 {
-    [Fact]
-    public void ComponentRendersWithoutCrashing()
-    {
-        // Arrange
-        var cut = RenderComponent<DateDropdown>();
+	[Fact]
+	public void ComponentRendersWithoutCrashing()
+	{
+		// Arrange
+		var cut = RenderComponent<DateDropdown>();
 
-        // Assert
-        cut.MarkupMatches(@"
+		// Assert
+		cut.MarkupMatches(@"
                 <ix-date-dropdown id="""" custom-range-allowed="""" date-range-id=""custom"" format=""yyyy/LL/dd"" i18n-custom-item=""Custom..."" i18n-done=""Done"" i18n-no-range=""No range set"" range=""""></ix-date-dropdown>
             ");
-    }
+	}
 
-    [Fact]
-    public void AllPropertiesAreSetCorrectly()
-    {
-        // Arrange
-        var dateDropdownOptions = new DateDropdownOption[] { new() { Id = "test", Label = "Test" } };
-        var dateRangeChangeEvent = new EventCallbackFactory().Create<DateDropdownResponse>(this, response =>
-        {
-            /* your action here */
-        });
+	[Fact]
+	public void AllPropertiesAreSetCorrectly()
+	{
+		// Arrange
+		var dateDropdownOptions = new DateDropdownOption[] { new() { Id = "test", Label = "Test" } };
+		var dateRangeChangeEvent = new EventCallbackFactory().Create<DateDropdownResponse>(this, response =>
+		{
+			/* your action here */
+		});
 
-        var cut = RenderComponent<DateDropdown>(parameters => parameters
-            .Add(p => p.Id, "testId")
-            .Add(p => p.CustomRangeAllowed, true)
-            .Add(p => p.DateRangeId, "custom")
-            .Add(p => p.DateRangeOptions, dateDropdownOptions)
-            .Add(p => p.Format, "yyyy/LL/dd")
-            .Add(p => p.From, "2022/01/01")
-            .Add(p => p.I18NCustomItem, "Custom...")
-            .Add(p => p.I18NDone, "Done")
-            .Add(p => p.I18NNoRange, "No range set")
-            .Add(p => p.MaxDate, "2022/12/31")
-            .Add(p => p.MinDate, "2022/01/01")
-            .Add(p => p.Range, true)
-            .Add(p => p.To, "2022/12/31")
-            .Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent));
+		var cut = RenderComponent<DateDropdown>(parameters => parameters
+			.Add(p => p.Id, "testId")
+			.Add(p => p.CustomRangeAllowed, true)
+			.Add(p => p.DateRangeId, "custom")
+			.Add(p => p.DateRangeOptions, dateDropdownOptions)
+			.Add(p => p.Format, "yyyy/LL/dd")
+			.Add(p => p.From, "2022/01/01")
+			.Add(p => p.I18NCustomItem, "Custom...")
+			.Add(p => p.I18NDone, "Done")
+			.Add(p => p.I18NNoRange, "No range set")
+			.Add(p => p.MaxDate, "2022/12/31")
+			.Add(p => p.MinDate, "2022/01/01")
+			.Add(p => p.Range, true)
+			.Add(p => p.To, "2022/12/31")
+			.Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent)
+			.Add(p => p.Disabled, true));
 
-        // Assert
-        cut.MarkupMatches(@"
-                <ix-date-dropdown id=""testId"" custom-range-allowed="""" date-range-id=""custom"" format=""yyyy/LL/dd"" from=""2022/01/01"" i18n-custom-item=""Custom..."" i18n-done=""Done"" i18n-no-range=""No range set"" max-date=""2022/12/31"" min-date=""2022/01/01"" range="""" to=""2022/12/31""></ix-date-dropdown>
+		// Assert
+		cut.MarkupMatches(@"
+                <ix-date-dropdown id=""testId"" custom-range-allowed="""" date-range-id=""custom"" format=""yyyy/LL/dd"" from=""2022/01/01"" i18n-custom-item=""Custom..."" i18n-done=""Done"" i18n-no-range=""No range set"" max-date=""2022/12/31"" min-date=""2022/01/01"" range="""" to=""2022/12/31"" disabled></ix-date-dropdown>
             ");
-    }
+	}
 
-    [Fact]
-    public void DateRangeChangeEventIsTriggeredCorrectly()
-    {
-        // Arrange
-        var dateDropdownOptions = new DateDropdownOption[]
-        {
-            new() { Id = "test", Label = "Test", From = "2022/01/01", To = "2022/12/31" },
-            new() { Id = "test2", Label = "Test2", From = "2023/01/01", To = "2023/12/31" }
-        };
-        var dateRangeChangeEventTriggered = false;
-        var dateRangeChangeEvent =
-            new EventCallbackFactory().Create<DateDropdownResponse>(this,
-                response => { dateRangeChangeEventTriggered = true; });
+	[Fact]
+	public void DateRangeChangeEventIsTriggeredCorrectly()
+	{
+		// Arrange
+		var dateDropdownOptions = new DateDropdownOption[]
+		{
+			new() { Id = "test", Label = "Test", From = "2022/01/01", To = "2022/12/31" },
+			new() { Id = "test2", Label = "Test2", From = "2023/01/01", To = "2023/12/31" }
+		};
+		var dateRangeChangeEventTriggered = false;
+		var dateRangeChangeEvent =
+			new EventCallbackFactory().Create<DateDropdownResponse>(this,
+				response => { dateRangeChangeEventTriggered = true; });
 
-        var cut = RenderComponent<DateDropdown>(parameters => parameters
-            .Add(p => p.Id, "testId")
-            .Add(p => p.CustomRangeAllowed, true)
-            .Add(p => p.DateRangeId, "test1")
-            .Add(p => p.DateRangeOptions, dateDropdownOptions)
-            .Add(p => p.Format, "yyyy/LL/dd")
-            .Add(p => p.From, "2022/01/01")
-            .Add(p => p.I18NCustomItem, "Custom...")
-            .Add(p => p.I18NDone, "Done")
-            .Add(p => p.I18NNoRange, "No range set")
-            .Add(p => p.MaxDate, "2022/12/31")
-            .Add(p => p.MinDate, "2022/01/01")
-            .Add(p => p.Range, true)
-            .Add(p => p.To, "2022/12/31")
-            .Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent));
+		var cut = RenderComponent<DateDropdown>(parameters => parameters
+			.Add(p => p.Id, "testId")
+			.Add(p => p.CustomRangeAllowed, true)
+			.Add(p => p.DateRangeId, "test1")
+			.Add(p => p.DateRangeOptions, dateDropdownOptions)
+			.Add(p => p.Format, "yyyy/LL/dd")
+			.Add(p => p.From, "2022/01/01")
+			.Add(p => p.I18NCustomItem, "Custom...")
+			.Add(p => p.I18NDone, "Done")
+			.Add(p => p.I18NNoRange, "No range set")
+			.Add(p => p.MaxDate, "2022/12/31")
+			.Add(p => p.MinDate, "2022/01/01")
+			.Add(p => p.Range, true)
+			.Add(p => p.To, "2022/12/31")
+			.Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent));
 
-        // Act
-        var json = JsonSerializer.Serialize(new DateDropdownResponse { Id = "test2" });
-        var parsedJson = JsonDocument.Parse(json).RootElement;
-        cut.Instance.DateRangeChange(parsedJson);
+		// Act
+		var json = JsonSerializer.Serialize(new DateDropdownResponse { Id = "test2" });
+		var parsedJson = JsonDocument.Parse(json).RootElement;
+		cut.Instance.DateRangeChange(parsedJson);
 
-        // Assert
-        Assert.True(dateRangeChangeEventTriggered);
-    }
+		// Assert
+		Assert.True(dateRangeChangeEventTriggered);
+	}
 }

--- a/SiemensIXBlazor.Tests/Menu/MenuItemTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuItemTest.cs
@@ -14,29 +14,30 @@ using SiemensIXBlazor.Components.Menu;
 namespace SiemensIXBlazor.Tests.Menu
 {
 	public class MenuItemTests : TestContextBase
-    {
-        [Fact]
-        public void MenuItemRendersCorrectly()
-        {
-            // Arrange
-            var cut = RenderComponent<MenuItem>(
-                ("Active", true),
-                ("Disabled", false),
-                ("Home", true),
-                ("Icon", "testIcon"),
-                ("Notifications", 5),
-                ("TabIcon", "document"),
-                ("ChildContent", (RenderFragment)(builder =>
-                {
-                    builder.OpenElement(0, "div");
-                    builder.AddContent(1, "Test child content");
-                    builder.CloseElement();
-                }))
-            );
+	{
+		[Fact]
+		public void MenuItemRendersCorrectly()
+		{
+			// Arrange
+			var cut = RenderComponent<MenuItem>(
+				("Active", true),
+				("Disabled", false),
+				("Home", true),
+				("Icon", "testIcon"),
+				("Notifications", 5),
+				("TabIcon", "document"),
+				("Label", "label"),
+				("ChildContent", (RenderFragment)(builder =>
+				{
+					builder.OpenElement(0, "div");
+					builder.AddContent(1, "Test child content");
+					builder.CloseElement();
+				}))
+			);
 
-            // Assert
-            // Adjust the expected markup to match your component's output
-            cut.MarkupMatches("<ix-menu-item active=\"\" home=\"\" icon=\"testIcon\" notifications=\"5\" tab-icon=\"document\"><div>Test child content</div></ix-menu-item>");
-        }
-    }
+			// Assert
+			// Adjust the expected markup to match your component's output
+			cut.MarkupMatches("<ix-menu-item active=\"\" home=\"\" icon=\"testIcon\" notifications=\"5\" tab-icon=\"document\" label=\"label\"><div>Test child content</div></ix-menu-item>");
+		}
+	}
 }

--- a/SiemensIXBlazor.Tests/Menu/MenuTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuTest.cs
@@ -10,43 +10,45 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 
-namespace SiemensIXBlazor.Tests.Menu
-{
-	public class MenuTest : TestContextBase
-    {
-        [Fact]
-        public void MenuRendersCorrectly()
-        {
-            // Arrange
-            var cut = RenderComponent<Components.Menu.Menu>(
-                    ("Id", "testId"),
-                    ("Class", "test-class"),
-                    ("Style", "width: 100%"),
-                    ("ApplicationName", "Test Application"),
-                    ("ApplicationDescription", "Test Description"),
-                    ("EnableMapExpand", true),
-                    ("EnableSettings", true),
-                    ("EnableToggleTheme", true),
-                    ("Expand", true),
-                    ("I18NCollapse", "Collapse"),
-                    ("I18NExpand", "Expand"),
-                    ("I18NLegal", "Legal"),
-                    ("I18NMore", "More"),
-                    ("I18NSettings", "Settings"),
-                    ("I18NToggleTheme", "Toggle Theme"),
-                    ("MaxVisibleMenuItems", 5),
-                    ("ShowAbout", true),
-                    ("ShowSettings", true),
-                    ("ChildContent", (RenderFragment)(builder =>
-                    {
-                        builder.OpenElement(0, "div");
-                        builder.AddContent(1, "Test child content");
-                        builder.CloseElement();
-                    }))
-                   );
+namespace SiemensIXBlazor.Tests.Menu;
 
-            // Assert
-            cut.MarkupMatches($@"
+public class MenuTest : TestContextBase
+{
+	[Fact]
+	public void MenuRendersCorrectly()
+	{
+		// Arrange
+		var cut = RenderComponent<Components.Menu.Menu>(
+				("Id", "testId"),
+				("Class", "test-class"),
+				("Style", "width: 100%"),
+				("ApplicationName", "Test Application"),
+				("ApplicationDescription", "Test Description"),
+				("EnableMapExpand", true),
+				("EnableSettings", true),
+				("EnableToggleTheme", true),
+				("Expand", true),
+				("I18NCollapse", "Collapse"),
+				("I18NExpand", "Expand"),
+				("I18NLegal", "Legal"),
+				("I18NMore", "More"),
+				("I18NSettings", "Settings"),
+				("I18NToggleTheme", "Toggle Theme"),
+				("MaxVisibleMenuItems", 5),
+				("ShowAbout", true),
+				("ShowSettings", true),
+				("StartExpanded", true),
+				("Pinned", true),
+				("ChildContent", (RenderFragment)(builder =>
+				{
+					builder.OpenElement(0, "div");
+					builder.AddContent(1, "Test child content");
+					builder.CloseElement();
+				}))
+				   );
+
+		// Assert
+		cut.MarkupMatches($@"
                 <ix-menu 
                     id='testId' 
                     class='test-class' 
@@ -65,45 +67,46 @@ namespace SiemensIXBlazor.Tests.Menu
                     i-1-8n-toggle-theme='Toggle Theme'
                     max-visible-menu-items='5'
                     show-about=''
+                    start-expanded
+					pinned
                     show-settings=''>
                     <div>Test child content</div>
                 </ix-menu>");
-            //cut.MarkupMatches("<ix-menu id=\"testId\" class=\"test-class\" style=\"width: 100%\" application-name=\"Test Application\" application-description=\"Test Description\" enable-map-expand=\"\" enable-settings=\"\" enable-toggle-theme=\"\" expand=\"\" i-1-8n-collapse=\"Collapse\" i-1-8n-expand=\"Expand\" i-1-8n-legal=\"Legal\" i-1-8n-more=\"More\" i-1-8n-settings=\"Settings\" i-1-8n-toggle-theme=\"Toggle Theme\" max-visible-menu-items=\"5\" show-about=\"\" show-settings=\"\"><div>Test child content</div></ix-menu>");
+		//cut.MarkupMatches("<ix-menu id=\"testId\" class=\"test-class\" style=\"width: 100%\" application-name=\"Test Application\" application-description=\"Test Description\" enable-map-expand=\"\" enable-settings=\"\" enable-toggle-theme=\"\" expand=\"\" i-1-8n-collapse=\"Collapse\" i-1-8n-expand=\"Expand\" i-1-8n-legal=\"Legal\" i-1-8n-more=\"More\" i-1-8n-settings=\"Settings\" i-1-8n-toggle-theme=\"Toggle Theme\" max-visible-menu-items=\"5\" show-about=\"\" show-settings=\"\"><div>Test child content</div></ix-menu>");
 
-        }
+	}
 
-        [Fact]
-        public async Task ExpandChangedEventWorks()
-        {
-            // Arrange
-            var expanded = false;
-            var cut = RenderComponent<Components.Menu.Menu>(
-                ("Id", "navMenu"),
-                ("ExpandChangedEvent", EventCallback.Factory.Create(this, (bool value) => expanded = value))
-            );
+	[Fact]
+	public async Task ExpandChangedEventWorks()
+	{
+		// Arrange
+		var expanded = false;
+		var cut = RenderComponent<Components.Menu.Menu>(
+			("Id", "navMenu"),
+			("ExpandChangedEvent", EventCallback.Factory.Create(this, (bool value) => expanded = value))
+		);
 
-            // Act
-            await cut.Instance.ExpandChanged(true);
+		// Act
+		await cut.Instance.ExpandChanged(true);
 
-            // Assert
-            Assert.True(expanded);
-        }
-        
-        [Fact]
-        public async Task MapExpandChangedEventWorks()
-        {
-            // Arrange
-            var mapExpanded = false;
-            var cut = RenderComponent<Components.Menu.Menu>(
-                ("Id", "navMenu"),
-                ("MapExpandChangedEvent", EventCallback.Factory.Create(this, (bool value) => mapExpanded = value))
-            );
+		// Assert
+		Assert.True(expanded);
+	}
 
-            // Act
-            await cut.Instance.MapExpandChanged(true);
+	[Fact]
+	public async Task MapExpandChangedEventWorks()
+	{
+		// Arrange
+		var mapExpanded = false;
+		var cut = RenderComponent<Components.Menu.Menu>(
+			("Id", "navMenu"),
+			("MapExpandChangedEvent", EventCallback.Factory.Create(this, (bool value) => mapExpanded = value))
+		);
 
-            // Assert
-            Assert.True(mapExpanded);
-        }
-    }
+		// Act
+		await cut.Instance.MapExpandChanged(true);
+
+		// Assert
+		Assert.True(mapExpanded);
+	}
 }

--- a/SiemensIXBlazor.Tests/SplitButton/SplitButtonTest.cs
+++ b/SiemensIXBlazor.Tests/SplitButton/SplitButtonTest.cs
@@ -9,50 +9,48 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using SiemensIXBlazor.Components;
 using SiemensIXBlazor.Enums.Button;
-using Xunit;
 
-namespace SiemensIXBlazor.Tests.SplitButton
+namespace SiemensIXBlazor.Tests.SplitButton;
+
+public class SplitButtonTests : TestContextBase
 {
-    public class SplitButtonTests : TestContextBase
-    {
-        [Fact]
-        public void SplitButtonRendersCorrectly()
-        {
-            // Arrange
-            var cut = RenderComponent<Components.SplitButton>(
-                ("Id", "testId"),
-                ("Disabled", true),
-                ("Ghost", true),
-                ("Icon", "test-icon"),
-                ("Label", "Test Label"),
-                ("Outline", true),
-                ("Placement", "bottom-start"),
-                ("SplitIcon", "context-menu"),
-                ("Variant", ButtonVariant.primary)
-            );
+	[Fact]
+	public void SplitButtonRendersCorrectly()
+	{
+		// Arrange
+		var cut = RenderComponent<Components.SplitButton>(
+			("Id", "testId"),
+			("Disabled", true),
+			("Ghost", true),
+			("Icon", "test-icon"),
+			("Label", "Test Label"),
+			("Outline", true),
+			("Placement", "bottom-start"),
+			("SplitIcon", "context-menu"),
+			("CloseBehavior", CloseBehavior.Both),
+			("Variant", ButtonVariant.primary)
+		);
 
-            // Assert
-            cut.MarkupMatches(
-                "<ix-split-button id=\"testId\" disabled ghost icon=\"test-icon\" label=\"Test Label\" outline placement=\"bottom-start\" split-icon=\"context-menu\" variant=\"primary\"></ix-split-button>");
-        }
+		// Assert
+		cut.MarkupMatches(
+			"<ix-split-button id=\"testId\" disabled ghost icon=\"test-icon\" label=\"Test Label\" outline placement=\"bottom-start\" split-icon=\"context-menu\" variant=\"primary\" close-behavior=\"both\"></ix-split-button>");
+	}
 
-        [Fact]
-        public void ButtonClickedEventWorks()
-        {
-            // Arrange
-            var buttonClicked = false;
-            var cut = RenderComponent<Components.SplitButton>(
-                ("Id", "testId"),
-                ("ButtonClickedEvent", EventCallback.Factory.Create(this, () => buttonClicked = true))
-            );
+	[Fact]
+	public void ButtonClickedEventWorks()
+	{
+		// Arrange
+		var buttonClicked = false;
+		var cut = RenderComponent<Components.SplitButton>(
+			("Id", "testId"),
+			("ButtonClickedEvent", EventCallback.Factory.Create(this, () => buttonClicked = true))
+		);
 
-            // Act
-            cut.Instance.ButtonClicked();
+		// Act
+		cut.Instance.ButtonClicked();
 
-            // Assert
-            Assert.True(buttonClicked);
-        }
-    }
+		// Assert
+		Assert.True(buttonClicked);
+	}
 }

--- a/SiemensIXBlazor/Components/CardList/CardList.razor
+++ b/SiemensIXBlazor/Components/CardList/CardList.razor
@@ -16,8 +16,8 @@
 @inject IJSRuntime JSRuntime
 
 <ix-card-list @attributes="UserAttributes" class="@Class" style="@Style" id="@Id" label="@Label"
-    show-all-count="@ShowAllCount" list-style="@(EnumParser<CardListStyle>.EnumToString(ListStyle))"
-    collapse="@Collapse" i-1-8n-more-cards="@I18NMoreCards" i-1-8n-show-all="@I18NShowAll"
-    suppress-overflow-handling="@SuppressOverflowHandling">
-    @ChildContent
+			  show-all-count="@ShowAllCount" list-style="@(EnumParser<CardListStyle>.EnumToString(ListStyle))"
+			  collapse="@Collapse" i-1-8n-more-cards="@I18NMoreCards" i-1-8n-show-all="@I18NShowAll"
+			  suppress-overflow-handling="@SuppressOverflowHandling" hide-show-all="@HideShowAll">
+	@ChildContent
 </ix-card-list>

--- a/SiemensIXBlazor/Components/CardList/CardList.razor.cs
+++ b/SiemensIXBlazor/Components/CardList/CardList.razor.cs
@@ -15,63 +15,65 @@ using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components
 {
-    public partial class CardList
-    {
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
-        [Parameter]
-        public bool Collapse { get; set; } = false;
-        [Parameter]
-        public string I18NMoreCards { get; set; } = "There are more cards available";
-        [Parameter]
-        public string I18NShowAll { get; set; } = "Show all";
-        [Parameter]
-        public string? Label { get; set; }
-        [Parameter]
-        public CardListStyle ListStyle { get; set; } = CardListStyle.Stack;
-        [Parameter]
-        public int? ShowAllCount { get; set; }
-        [Parameter]
-        public bool SuppressOverflowHandling { get; set; } = false;
-        [Parameter]
-        public EventCallback<bool> CollapseChangedEvent { get; set; }
-        [Parameter]
-        public EventCallback ShowAllClickEvent { get; set; }
-        [Parameter]
-        public EventCallback ShowMoreCardClickEvent { get; set; }
+	public partial class CardList
+	{
+		[Parameter, EditorRequired]
+		public string Id { get; set; } = string.Empty;
+		[Parameter]
+		public RenderFragment? ChildContent { get; set; }
+		[Parameter]
+		public bool Collapse { get; set; } = false;
+		[Parameter]
+		public string I18NMoreCards { get; set; } = "There are more cards available";
+		[Parameter]
+		public string I18NShowAll { get; set; } = "Show all";
+		[Parameter]
+		public string? Label { get; set; }
+		[Parameter]
+		public CardListStyle ListStyle { get; set; } = CardListStyle.Stack;
+		[Parameter]
+		public int? ShowAllCount { get; set; }
+		[Parameter]
+		public bool HideShowAll { get; set; } = false;
+		[Parameter]
+		public bool SuppressOverflowHandling { get; set; } = false;
+		[Parameter]
+		public EventCallback<bool> CollapseChangedEvent { get; set; }
+		[Parameter]
+		public EventCallback ShowAllClickEvent { get; set; }
+		[Parameter]
+		public EventCallback ShowMoreCardClickEvent { get; set; }
 
-        private BaseInterop _interop;
+		private BaseInterop _interop;
 
-        protected async override Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                _interop = new(JSRuntime);
+		protected async override Task OnAfterRenderAsync(bool firstRender)
+		{
+			if (firstRender)
+			{
+				_interop = new(JSRuntime);
 
-                await _interop.AddEventListener(this, Id, "collapseChanged", "CollapseChanged");
-                await _interop.AddEventListener(this, Id, "showAllClick", "ShowAllClicked");
-                await _interop.AddEventListener(this, Id, "showMoreCardClick", "ShowMoreCardClicked");
-            }
-        }
+				await _interop.AddEventListener(this, Id, "collapseChanged", "CollapseChanged");
+				await _interop.AddEventListener(this, Id, "showAllClick", "ShowAllClicked");
+				await _interop.AddEventListener(this, Id, "showMoreCardClick", "ShowMoreCardClicked");
+			}
+		}
 
-        [JSInvokable]
-        public async void CollapseChanged(bool value)
-        {
-            await CollapseChangedEvent.InvokeAsync(value);
-        }
+		[JSInvokable]
+		public async void CollapseChanged(bool value)
+		{
+			await CollapseChangedEvent.InvokeAsync(value);
+		}
 
-        [JSInvokable]
-        public async void ShowAllClicked()
-        {
-            await ShowAllClickEvent.InvokeAsync();
-        }
+		[JSInvokable]
+		public async void ShowAllClicked()
+		{
+			await ShowAllClickEvent.InvokeAsync();
+		}
 
-        [JSInvokable]
-        public async void ShowMoreCardClicked()
-        {
-            await ShowMoreCardClickEvent.InvokeAsync();
-        }
-    }
+		[JSInvokable]
+		public async void ShowMoreCardClicked()
+		{
+			await ShowMoreCardClickEvent.InvokeAsync();
+		}
+	}
 }

--- a/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor
+++ b/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor
@@ -22,5 +22,8 @@ hide-icon="@HideIcon"
 i-1-8n-plain-text="@I18nPlainText"
 icon="@Icon"
 label-categories="@LabelCategories"
-repeat-categories="@RepeatCategories"></ix-category-filter>
+repeat-categories="@RepeatCategories"
+disabled="@Disabled"
+readonly="@Readonly">
+</ix-category-filter>
 

--- a/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
+++ b/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
@@ -67,6 +67,10 @@ namespace SiemensIXBlazor.Components.CategoryFilter
         [Parameter]
         public bool RepeatCategories { get; set; } = true;
         [Parameter]
+        public bool Disabled { get; set; } = false;
+        [Parameter]
+        public bool Readonly { get; set; } = false;
+        [Parameter]
         public string[]? Suggestions
         {
             get => _suggestions;

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
@@ -14,21 +14,20 @@
 @inject IJSRuntime JsRuntime
 @inherits IXBaseComponent
 
-<ix-date-dropdown
-    @attributes="UserAttributes"
-    style="@Style"
-    class="@Class"
-    id="@Id"
-    custom-range-allowed="@CustomRangeAllowed"
-    date-range-id="@DateRangeId"
-    format="@Format"
-    from="@From"
-    i18n-custom-item="@I18NCustomItem"
-    i18n-done="@I18NDone"
-    i18n-no-range="@I18NNoRange"
-    max-date="@MaxDate"
-    min-date="@MinDate"
-    range="@Range"
-    to="@To">
-
+<ix-date-dropdown @attributes="UserAttributes"
+				  style="@Style"
+				  class="@Class"
+				  id="@Id"
+				  custom-range-allowed="@CustomRangeAllowed"
+				  date-range-id="@DateRangeId"
+				  format="@Format"
+				  from="@From"
+				  i18n-custom-item="@I18NCustomItem"
+				  i18n-done="@I18NDone"
+				  i18n-no-range="@I18NNoRange"
+				  max-date="@MaxDate"
+				  min-date="@MinDate"
+				  range="@Range"
+				  to="@To"
+				  disabled="@Disabled">
 </ix-date-dropdown>

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
@@ -7,7 +7,6 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using System.Text.Json;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Newtonsoft.Json;
@@ -15,76 +14,81 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects.DateDropdown;
+using System.Text.Json;
 
 namespace SiemensIXBlazor.Components;
 
 public partial class DateDropdown
 {
-    private BaseInterop _interop = null!;
-    private Lazy<Task<IJSObjectReference>>? _moduleTask;
+	private BaseInterop _interop = null!;
+	private Lazy<Task<IJSObjectReference>>? _moduleTask;
 
-    [Parameter][EditorRequired] public string Id { get; set; } = string.Empty;
+	[Parameter, EditorRequired]
+	public string Id { get; set; } = string.Empty;
+	[Parameter]
+	public bool CustomRangeAllowed { get; set; } = true;
+	[Parameter]
+	public string DateRangeId { get; set; } = "custom";
+	[Parameter]
+	public EventCallback<string> DateRangeIdChanged { get; set; }
+	[Parameter]
+	public DateDropdownOption[]? DateRangeOptions { get; set; }
+	[Parameter]
+	public string Format { get; set; } = "yyyy/LL/dd";
+	[Parameter]
+	public string? From { get; set; }
+	[Parameter]
+	public string I18NCustomItem { get; set; } = "Custom...";
+	[Parameter]
+	public string I18NDone { get; set; } = "Done";
+	[Parameter]
+	public string I18NNoRange { get; set; } = "No range set";
+	[Parameter]
+	public string? MaxDate { get; set; }
+	[Parameter]
+	public string? MinDate { get; set; }
+	[Parameter]
+	public bool Range { get; set; } = true;
+	[Parameter]
+	public string? To { get; set; }
+	[Parameter]
+	public bool Disabled { get; set; } = false;
+	[Parameter]
+	public EventCallback<DateDropdownResponse> DateRangeChangeEvent { get; set; }
 
-    [Parameter] public bool CustomRangeAllowed { get; set; } = true;
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			await InitialParameterAsync("setDateRangeOptions", DateRangeOptions);
+			_interop = new BaseInterop(JsRuntime);
 
-    [Parameter] public string DateRangeId { get; set; } = "custom";
+			await _interop.AddEventListener(this, Id, "dateRangeChange", "DateRangeChange");
+		}
+	}
 
-    [Parameter] public EventCallback<string> DateRangeIdChanged { get; set; }
+	private async Task InitialParameterAsync(string functionName, object? param)
+	{
+		_moduleTask = new Lazy<Task<IJSObjectReference>>(() => JsRuntime.InvokeAsync<IJSObjectReference>(
+			"import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/dateDropdownInterop.js").AsTask());
 
-    [Parameter] public DateDropdownOption[]? DateRangeOptions { get; set; }
+		var dateRangeOptions = JsonConvert.SerializeObject(param, new JsonSerializerSettings
+		{
+			ContractResolver = new CamelCasePropertyNamesContractResolver()
+		});
 
-    [Parameter] public string Format { get; set; } = "yyyy/LL/dd";
+		var module = await _moduleTask.Value;
+		if (module != null)
+			await module.InvokeVoidAsync(functionName, Id, dateRangeOptions);
+	}
 
-    [Parameter] public string? From { get; set; }
+	[JSInvokable]
+	public async void DateRangeChange(JsonElement data)
+	{
+		var jsonDataText = data.GetRawText();
+		var jsonData = JObject.Parse(jsonDataText)
+			.ToObject<DateDropdownResponse>();
 
-    [Parameter] public string I18NCustomItem { get; set; } = "Custom...";
-
-    [Parameter] public string I18NDone { get; set; } = "Done";
-
-    [Parameter] public string I18NNoRange { get; set; } = "No range set";
-
-    [Parameter] public string? MaxDate { get; set; }
-
-    [Parameter] public string? MinDate { get; set; }
-
-    [Parameter] public bool Range { get; set; } = true;
-
-    [Parameter] public string? To { get; set; }
-
-    [Parameter] public EventCallback<DateDropdownResponse> DateRangeChangeEvent { get; set; }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await InitialParameterAsync("setDateRangeOptions", DateRangeOptions);
-            _interop = new BaseInterop(JsRuntime);
-
-            await _interop.AddEventListener(this, Id, "dateRangeChange", "DateRangeChange");
-        }
-    }
-
-    private async Task InitialParameterAsync(string functionName, object? param)
-    {
-        _moduleTask = new Lazy<Task<IJSObjectReference>>(() => JsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/dateDropdownInterop.js").AsTask());
-
-        var dateRangeOptions = JsonConvert.SerializeObject(param, new JsonSerializerSettings
-        {
-            ContractResolver = new CamelCasePropertyNamesContractResolver()
-        });
-
-        var module = await _moduleTask.Value;
-        if (module != null) await module.InvokeVoidAsync(functionName, Id, dateRangeOptions);
-    }
-
-    [JSInvokable]
-    public async void DateRangeChange(JsonElement data)
-    {
-        var jsonDataText = data.GetRawText();
-        var jsonData = JObject.Parse(jsonDataText)
-            .ToObject<DateDropdownResponse>();
-
-        await DateRangeChangeEvent.InvokeAsync(jsonData);
-    }
+		await DateRangeChangeEvent.InvokeAsync(jsonData);
+	}
 }

--- a/SiemensIXBlazor/Components/Menu/Menu.razor
+++ b/SiemensIXBlazor/Components/Menu/Menu.razor
@@ -12,25 +12,26 @@
 @inject IJSRuntime JSRuntime
 @inherits IXBaseComponent
 
-<ix-menu
-         id="@Id"
-         @attributes="UserAttributes"
-         class="@Class"
-         style="@Style"
-         application-description="@ApplicationDescription"
-         application-name="@ApplicationName"
-         enable-map-expand="@EnableMapExpand"
-         enable-settings="@EnableSettings"
-         enable-toggle-theme="@EnableToggleTheme"
-         expand="@Expand"
-         i-1-8n-collapse="@I18NCollapse"
-         i-1-8n-expand="@I18NExpand"
-         i-1-8n-legal="@I18NLegal"
-         i-1-8n-more="@I18NMore"
-         i-1-8n-settings="@I18NSettings"
-         i-1-8n-toggle-theme="@I18NToggleTheme"
-         max-visible-menu-items="@MaxVisibleMenuItems"
-         show-about="@ShowAbout"
-         show-settings="@ShowSettings">
-    @ChildContent
+<ix-menu id="@Id"
+		 @attributes="UserAttributes"
+		 class="@Class"
+		 style="@Style"
+		 application-description="@ApplicationDescription"
+		 application-name="@ApplicationName"
+		 enable-map-expand="@EnableMapExpand"
+		 enable-settings="@EnableSettings"
+		 enable-toggle-theme="@EnableToggleTheme"
+		 expand="@Expand"
+		 i-1-8n-collapse="@I18NCollapse"
+		 i-1-8n-expand="@I18NExpand"
+		 i-1-8n-legal="@I18NLegal"
+		 i-1-8n-more="@I18NMore"
+		 i-1-8n-settings="@I18NSettings"
+		 i-1-8n-toggle-theme="@I18NToggleTheme"
+		 max-visible-menu-items="@MaxVisibleMenuItems"
+		 show-about="@ShowAbout"
+		 show-settings="@ShowSettings"
+		 start-expanded="@StartExpanded"
+		 pinned="@Pinned">
+	@ChildContent
 </ix-menu>

--- a/SiemensIXBlazor/Components/Menu/Menu.razor.cs
+++ b/SiemensIXBlazor/Components/Menu/Menu.razor.cs
@@ -13,70 +13,74 @@ using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components.Menu
 {
-    public partial class Menu
-    {
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
-        [Parameter]
-        public string ApplicationDescription { get; set; } = string.Empty;
-        [Parameter]
-        public string? ApplicationName { get; set; }
-        [Parameter]
-        public bool EnableMapExpand { get; set; } = false;
-        [Parameter]
-        public bool EnableSettings { get; set; } = false;
-        [Parameter]
-        public bool EnableToggleTheme { get; set; } = false;
-        [Parameter]
-        public bool Expand { get; set; } = false;
-        [Parameter]
-        public string I18NCollapse { get; set; } = "Collapse";
-        [Parameter]
-        public string I18NExpand { get; set; } = "Expand";
-        [Parameter]
-        public string I18NLegal { get; set; } = "About & legal information";
-        [Parameter]
-        public string I18NMore { get; set; } = "More...";
-        [Parameter]
-        public string I18NSettings { get; set; } = "Settings";
-        [Parameter]
-        public string I18NToggleTheme { get; set; } = "Toggle theme";
-        [Parameter]
-        public int MaxVisibleMenuItems { get; set; } = 9;
-        [Parameter]
-        public bool ShowAbout { get; set; } = false;
-        [Parameter]
-        public bool ShowSettings { get; set; } = false;
-        [Parameter]
-        public EventCallback<bool> ExpandChangedEvent { get; set; }
-        [Parameter]
-        public EventCallback<bool> MapExpandChangedEvent { get; set; }
+	public partial class Menu
+	{
+		[Parameter]
+		public RenderFragment? ChildContent { get; set; }
+		[Parameter, EditorRequired]
+		public string Id { get; set; } = string.Empty;
+		[Parameter]
+		public string ApplicationDescription { get; set; } = string.Empty;
+		[Parameter]
+		public string? ApplicationName { get; set; }
+		[Parameter]
+		public bool EnableMapExpand { get; set; } = false;
+		[Parameter]
+		public bool EnableSettings { get; set; } = false;
+		[Parameter]
+		public bool EnableToggleTheme { get; set; } = false;
+		[Parameter]
+		public bool Expand { get; set; } = false;
+		[Parameter]
+		public string I18NCollapse { get; set; } = "Collapse";
+		[Parameter]
+		public string I18NExpand { get; set; } = "Expand";
+		[Parameter]
+		public string I18NLegal { get; set; } = "About & legal information";
+		[Parameter]
+		public string I18NMore { get; set; } = "More...";
+		[Parameter]
+		public string I18NSettings { get; set; } = "Settings";
+		[Parameter]
+		public string I18NToggleTheme { get; set; } = "Toggle theme";
+		[Parameter]
+		public int MaxVisibleMenuItems { get; set; } = 9;
+		[Parameter]
+		public bool ShowAbout { get; set; } = false;
+		[Parameter]
+		public bool ShowSettings { get; set; } = false;
+		[Parameter]
+		public bool StartExpanded { get; set; } = false;
+		[Parameter]
+		public bool Pinned { get; set; } = false;
+		[Parameter]
+		public EventCallback<bool> ExpandChangedEvent { get; set; }
+		[Parameter]
+		public EventCallback<bool> MapExpandChangedEvent { get; set; }
 
-        private BaseInterop _interop;
+		private BaseInterop _interop;
 
-        protected async override Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                _interop = new(JSRuntime);
+		protected async override Task OnAfterRenderAsync(bool firstRender)
+		{
+			if (firstRender)
+			{
+				_interop = new(JSRuntime);
 
-                await _interop.AddEventListener(this, Id, "expandChange", "ExpandChanged");
-                await _interop.AddEventListener(this, Id, "mapExpandChange", "MapExpandChanged");
-            }
-        }
+				await _interop.AddEventListener(this, Id, "expandChange", "ExpandChanged");
+				await _interop.AddEventListener(this, Id, "mapExpandChange", "MapExpandChanged");
+			}
+		}
 
-        [JSInvokable]
-        public async Task ExpandChanged(bool value)
-        {
-            await ExpandChangedEvent.InvokeAsync(value);
-        }
+		[JSInvokable]
+		public async Task ExpandChanged(bool value)
+		{
+			await ExpandChangedEvent.InvokeAsync(value);
+		}
 
-        [JSInvokable]
-        public async Task MapExpandChanged(bool value)
-        {
-            await MapExpandChangedEvent.InvokeAsync(value);
-        }
-    }
+		[JSInvokable]
+		public async Task MapExpandChanged(bool value)
+		{
+			await MapExpandChangedEvent.InvokeAsync(value);
+		}
+	}
 }

--- a/SiemensIXBlazor/Components/Menu/MenuItem.razor
+++ b/SiemensIXBlazor/Components/Menu/MenuItem.razor
@@ -10,15 +10,15 @@
 
 @inherits IXBaseComponent
 
-<ix-menu-item
-@attributes="UserAttributes"
-class="@Class"
-style="@Style"
-home="@Home" 
-tab-icon="@TabIcon"
-icon="@Icon"
-active="@Active"
-disabled="@Disabled"
-notifications="@Notifications"> 
-    @ChildContent 
+<ix-menu-item @attributes="UserAttributes"
+			  class="@Class"
+			  style="@Style"
+			  home="@Home"
+			  tab-icon="@TabIcon"
+			  icon="@Icon"
+			  active="@Active"
+			  disabled="@Disabled"
+			  notifications="@Notifications"
+			  label="@Label">
+	@ChildContent
 </ix-menu-item>

--- a/SiemensIXBlazor/Components/Menu/MenuItem.razor.cs
+++ b/SiemensIXBlazor/Components/Menu/MenuItem.razor.cs
@@ -11,21 +11,23 @@ using Microsoft.AspNetCore.Components;
 
 namespace SiemensIXBlazor.Components.Menu
 {
-    public partial class MenuItem : IXBaseComponent
-    {
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
-        [Parameter]
-        public bool? Active { get; set; }
-        [Parameter]
-        public bool? Disabled { get; set; }
-        [Parameter]
-        public bool Home { get; set; } = false;
-        [Parameter]
-        public string? Icon { get; set; }
-        [Parameter]
-        public int? Notifications { get; set; }
-        [Parameter]
-        public string TabIcon { get; set; } = "document";
-    }
+	public partial class MenuItem : IXBaseComponent
+	{
+		[Parameter]
+		public RenderFragment? ChildContent { get; set; }
+		[Parameter]
+		public bool? Active { get; set; }
+		[Parameter]
+		public bool? Disabled { get; set; }
+		[Parameter]
+		public bool Home { get; set; } = false;
+		[Parameter]
+		public string? Icon { get; set; }
+		[Parameter]
+		public int? Notifications { get; set; }
+		[Parameter]
+		public string TabIcon { get; set; } = "document";
+		[Parameter]
+		public string? Label { get; set; }
+	}
 }

--- a/SiemensIXBlazor/Components/SplitButton/SplitButton.razor
+++ b/SiemensIXBlazor/Components/SplitButton/SplitButton.razor
@@ -15,8 +15,18 @@
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
 
-<ix-split-button @attributes="UserAttributes" id="@Id" label="@Label" split-icon="@SplitIcon" disabled="@Disabled"
-    ghost="@Ghost" icon="@Icon" outline="@Outline" placement="@Placement" style="@Style" class="@Class"
-    variant="@(EnumParser<ButtonVariant>.EnumToString(Variant))">
-    @ChildContent
+<ix-split-button @attributes="UserAttributes"
+				 id="@Id"
+				 label="@Label"
+				 split-icon="@SplitIcon"
+				 disabled="@Disabled"
+				 ghost="@Ghost"
+				 icon="@Icon"
+				 outline="@Outline"
+				 placement="@Placement"
+				 style="@Style"
+				 class="@Class"
+				 close-behavior="@(EnumParser<CloseBehavior>.EnumToString(CloseBehavior))"
+				 variant="@(EnumParser<ButtonVariant>.EnumToString(Variant))">
+	@ChildContent
 </ix-split-button>

--- a/SiemensIXBlazor/Components/SplitButton/SplitButton.razor.cs
+++ b/SiemensIXBlazor/Components/SplitButton/SplitButton.razor.cs
@@ -8,54 +8,54 @@
 //  -----------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using SiemensIXBlazor.Enums.Button;
 using SiemensIXBlazor.Interops;
 
-namespace SiemensIXBlazor.Components
+namespace SiemensIXBlazor.Components;
+
+public partial class SplitButton
 {
-    public partial class SplitButton
-    {
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
-        [Parameter]
-        public bool Disabled { get; set; } = false;
-        [Parameter]
-        public bool Ghost { get; set; } = false;
-        [Parameter]
-        public string Icon { get; set; } = string.Empty;
-        [Parameter]
-        public string? Label { get; set; }
-        [Parameter]
-        public bool Outline { get; set; } = false;
-        [Parameter]
-        public string Placement { get; set; } = "bottom-start";
-        [Parameter]
-        public string SplitIcon { get; set; } = "context-menu";
-        [Parameter]
-        public ButtonVariant Variant { get; set; } = ButtonVariant.primary;
-        [Parameter]
-        public EventCallback ButtonClickedEvent { get; set; }
+	[Parameter]
+	public RenderFragment? ChildContent { get; set; }
+	[Parameter, EditorRequired]
+	public string Id { get; set; } = string.Empty;
+	[Parameter]
+	public bool Disabled { get; set; } = false;
+	[Parameter]
+	public bool Ghost { get; set; } = false;
+	[Parameter]
+	public string Icon { get; set; } = string.Empty;
+	[Parameter]
+	public string? Label { get; set; }
+	[Parameter]
+	public bool Outline { get; set; } = false;
+	[Parameter]
+	public string Placement { get; set; } = "bottom-start";
+	[Parameter]
+	public string SplitIcon { get; set; } = "context-menu";
+	[Parameter]
+	public CloseBehavior CloseBehavior { get; set; } = CloseBehavior.Both;
+	[Parameter]
+	public ButtonVariant Variant { get; set; } = ButtonVariant.primary;
+	[Parameter]
+	public EventCallback ButtonClickedEvent { get; set; }
 
-        private BaseInterop _interop;
+	private BaseInterop _interop;
 
-        protected async override Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                _interop = new(JSRuntime);
+	protected async override Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			_interop = new(JSRuntime);
 
-                await _interop.AddEventListener(this, Id, "buttonClick", "ButtonClicked");
-            }
-        }
+			await _interop.AddEventListener(this, Id, "buttonClick", "ButtonClicked");
+		}
+	}
 
-        [JSInvokable]
-        public async void ButtonClicked()
-        {
-            await ButtonClickedEvent.InvokeAsync();
-        }
-    }
+	[JSInvokable]
+	public async void ButtonClicked()
+	{
+		await ButtonClickedEvent.InvokeAsync();
+	}
 }

--- a/SiemensIXBlazor/Enums/Button/ButtonVariant.cs
+++ b/SiemensIXBlazor/Enums/Button/ButtonVariant.cs
@@ -12,6 +12,7 @@ namespace SiemensIXBlazor.Enums.Button
     public enum ButtonVariant
     {
         primary,
-        secondary
+        secondary,
+        danger
     }
 }

--- a/SiemensIXBlazor/Enums/Button/SplitButtonCloseBehavior.cs
+++ b/SiemensIXBlazor/Enums/Button/SplitButtonCloseBehavior.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.Button;
+
+public enum CloseBehavior
+{
+	Both,
+	Inside,
+	Outside,
+	True,
+	False
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

Some components did not have features added until ix@2.5.0 since ix@2.2.0, for example:

- Menu component - Pinned property
- MenuItem component - Label property
- Button component - Danger variant
- SplitButton component - Close behavior
- DateDropdown component - Disabled property
- CardList component - HideShowAll property
- CategoryFilter component - Disabled and Readonly properties


## 🆕 What is the new behavior?

Components are updated with new properties and variants along with unit tests. (version ix@2.5.0)

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

