### PR TITLE
Add New Properties to Select and DateDropdown Components

### DIFF
--- a/SiemensIXBlazor.Tests/DateDropdownTest.cs
+++ b/SiemensIXBlazor.Tests/DateDropdownTest.cs
@@ -19,87 +19,90 @@ namespace SiemensIXBlazor.Tests;
 
 public class DateDropdownTest : TestContextBase
 {
-	[Fact]
-	public void ComponentRendersWithoutCrashing()
-	{
-		// Arrange
-		var cut = RenderComponent<DateDropdown>();
+    [Fact]
+    public void ComponentRendersWithoutCrashing()
+    {
+        // Arrange
+        var cut = RenderComponent<DateDropdown>();
 
-		// Assert
-		cut.MarkupMatches(@"
-                <ix-date-dropdown id="""" custom-range-allowed="""" date-range-id=""custom"" format=""yyyy/LL/dd"" i18n-custom-item=""Custom..."" i18n-done=""Done"" i18n-no-range=""No range set"" range=""""></ix-date-dropdown>
+        // Assert
+        cut.MarkupMatches(@"
+                <ix-date-dropdown id='' custom-range-allowed='' week-start-index='0' date-range-id='custom' format='yyyy/LL/dd' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' range=''></ix-date-dropdown>
             ");
-	}
+    }
 
-	[Fact]
-	public void AllPropertiesAreSetCorrectly()
-	{
-		// Arrange
-		var dateDropdownOptions = new DateDropdownOption[] { new() { Id = "test", Label = "Test" } };
-		var dateRangeChangeEvent = new EventCallbackFactory().Create<DateDropdownResponse>(this, response =>
-		{
-			/* your action here */
-		});
+    [Fact]
+    public void AllPropertiesAreSetCorrectly()
+    {
+        // Arrange
+        var dateDropdownOptions = new DateDropdownOption[] { new() { Id = "test", Label = "Test" } };
+        var dateRangeChangeEvent = new EventCallbackFactory().Create<DateDropdownResponse>(this, response =>
+        {
+            /* your action here */
+        });
 
-		var cut = RenderComponent<DateDropdown>(parameters => parameters
-			.Add(p => p.Id, "testId")
-			.Add(p => p.CustomRangeAllowed, true)
-			.Add(p => p.DateRangeId, "custom")
-			.Add(p => p.DateRangeOptions, dateDropdownOptions)
-			.Add(p => p.Format, "yyyy/LL/dd")
-			.Add(p => p.From, "2022/01/01")
-			.Add(p => p.I18NCustomItem, "Custom...")
-			.Add(p => p.I18NDone, "Done")
-			.Add(p => p.I18NNoRange, "No range set")
-			.Add(p => p.MaxDate, "2022/12/31")
-			.Add(p => p.MinDate, "2022/01/01")
-			.Add(p => p.Range, true)
-			.Add(p => p.To, "2022/12/31")
-			.Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent)
-			.Add(p => p.Disabled, true));
+        var cut = RenderComponent<DateDropdown>(parameters => parameters
+            .Add(p => p.Id, "testId")
+            .Add(p => p.CustomRangeAllowed, true)
+            .Add(p => p.DateRangeId, "custom")
+            .Add(p => p.DateRangeOptions, dateDropdownOptions)
+            .Add(p => p.Format, "yyyy/LL/dd")
+            .Add(p => p.From, "2022/01/01")
+            .Add(p => p.I18NCustomItem, "Custom...")
+            .Add(p => p.I18NDone, "Done")
+            .Add(p => p.I18NNoRange, "No range set")
+            .Add(p => p.MaxDate, "2022/12/31")
+            .Add(p => p.MinDate, "2022/01/01")
+            .Add(p => p.Range, true)
+            .Add(p => p.To, "2022/12/31")
+            .Add(p => p.Locale, "en")
+            .Add(p => p.WeekStartIndex, 2)
+            .Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent)
+            .Add(p => p.Disabled, true));
 
-		// Assert
-		cut.MarkupMatches(@"
-                <ix-date-dropdown id=""testId"" custom-range-allowed="""" date-range-id=""custom"" format=""yyyy/LL/dd"" from=""2022/01/01"" i18n-custom-item=""Custom..."" i18n-done=""Done"" i18n-no-range=""No range set"" max-date=""2022/12/31"" min-date=""2022/01/01"" range="""" to=""2022/12/31"" disabled></ix-date-dropdown>
+        // Assert
+        cut.MarkupMatches(@"
+                <ix-date-dropdown id='testId' locale='en' week-start-index='2' custom-range-allowed='' date-range-id='custom' format='yyyy/LL/dd' from='2022/01/01' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' max-date='2022/12/31' min-date='2022/01/01' range='' to='2022/12/31' disabled></ix-date-dropdown>
             ");
-	}
+    }
 
-	[Fact]
-	public void DateRangeChangeEventIsTriggeredCorrectly()
-	{
-		// Arrange
-		var dateDropdownOptions = new DateDropdownOption[]
-		{
-			new() { Id = "test", Label = "Test", From = "2022/01/01", To = "2022/12/31" },
-			new() { Id = "test2", Label = "Test2", From = "2023/01/01", To = "2023/12/31" }
-		};
-		var dateRangeChangeEventTriggered = false;
-		var dateRangeChangeEvent =
-			new EventCallbackFactory().Create<DateDropdownResponse>(this,
-				response => { dateRangeChangeEventTriggered = true; });
+    [Fact]
+    public void DateRangeChangeEventIsTriggeredCorrectly()
+    {
+        // Arrange
+        var dateDropdownOptions = new DateDropdownOption[]
+        {
+            new() { Id = "test", Label = "Test", From = "2022/01/01", To = "2022/12/31" },
+            new() { Id = "test2", Label = "Test2", From = "2023/01/01", To = "2023/12/31" }
+        };
+        var dateRangeChangeEventTriggered = false;
+        var dateRangeChangeEvent =
+            new EventCallbackFactory().Create<DateDropdownResponse>(this,
+                response => { dateRangeChangeEventTriggered = true; });
 
-		var cut = RenderComponent<DateDropdown>(parameters => parameters
-			.Add(p => p.Id, "testId")
-			.Add(p => p.CustomRangeAllowed, true)
-			.Add(p => p.DateRangeId, "test1")
-			.Add(p => p.DateRangeOptions, dateDropdownOptions)
-			.Add(p => p.Format, "yyyy/LL/dd")
-			.Add(p => p.From, "2022/01/01")
-			.Add(p => p.I18NCustomItem, "Custom...")
-			.Add(p => p.I18NDone, "Done")
-			.Add(p => p.I18NNoRange, "No range set")
-			.Add(p => p.MaxDate, "2022/12/31")
-			.Add(p => p.MinDate, "2022/01/01")
-			.Add(p => p.Range, true)
-			.Add(p => p.To, "2022/12/31")
-			.Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent));
+        var cut = RenderComponent<DateDropdown>(parameters => parameters
+            .Add(p => p.Id, "testId")
+            .Add(p => p.CustomRangeAllowed, true)
+            .Add(p => p.DateRangeId, "test1")
+            .Add(p => p.DateRangeOptions, dateDropdownOptions)
+            .Add(p => p.Format, "yyyy/LL/dd")
+            .Add(p => p.From, "2022/01/01")
+            .Add(p => p.I18NCustomItem, "Custom...")
+            .Add(p => p.I18NDone, "Done")
+            .Add(p => p.I18NNoRange, "No range set")
+            .Add(p => p.MaxDate, "2022/12/31")
+            .Add(p => p.MinDate, "2022/01/01")
+            .Add(p => p.Range, true)
+            .Add(p => p.To, "2022/12/31")
+            .Add(p => p.WeekStartIndex, 0)
+            .Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent));
 
-		// Act
-		var json = JsonSerializer.Serialize(new DateDropdownResponse { Id = "test2" });
-		var parsedJson = JsonDocument.Parse(json).RootElement;
-		cut.Instance.DateRangeChange(parsedJson);
+        // Act
+        var json = JsonSerializer.Serialize(new DateDropdownResponse { Id = "test2" });
+        var parsedJson = JsonDocument.Parse(json).RootElement;
+        cut.Instance.DateRangeChange(parsedJson);
 
-		// Assert
-		Assert.True(dateRangeChangeEventTriggered);
-	}
+        // Assert
+        Assert.True(dateRangeChangeEventTriggered);
+    }
 }

--- a/SiemensIXBlazor.Tests/Select/SelectItemTest.cs
+++ b/SiemensIXBlazor.Tests/Select/SelectItemTest.cs
@@ -1,0 +1,163 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Components;
+
+namespace SiemensIXBlazor.Tests.Select;
+
+public class SelectItemTests : TestContextBase
+{
+    [Fact]
+    public void ComponentRendersWithoutCrashing()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item"));
+
+        // Assert
+        cut.MarkupMatches("<ix-select-item id='test-select-item'></ix-select-item>");
+    }
+
+    [Fact]
+    public void IdPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "custom-item-id"));
+
+        // Assert
+        Assert.Equal("custom-item-id", cut.Instance.Id);
+        cut.MarkupMatches("<ix-select-item id='custom-item-id'></ix-select-item>");
+    }
+
+    [Fact]
+    public void LabelPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.Label, "Test Label"));
+
+        // Assert
+        Assert.Equal("Test Label", cut.Instance.Label);
+        cut.MarkupMatches("<ix-select-item id='test-select-item' label='Test Label'></ix-select-item>");
+    }
+
+    [Fact]
+    public void ValuePropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.Value, "item-value"));
+
+        // Assert
+        Assert.Equal("item-value", cut.Instance.Value);
+        cut.MarkupMatches("<ix-select-item id='test-select-item' value='item-value'></ix-select-item>");
+    }
+
+    [Fact]
+    public void SelectedPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.Selected, true));
+
+        // Assert
+        Assert.True(cut.Instance.Selected);
+        cut.MarkupMatches("<ix-select-item id='test-select-item' selected></ix-select-item>");
+    }
+
+    [Fact]
+    public void ClassPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.Class, "custom-class"));
+
+        // Assert
+        Assert.Equal("custom-class", cut.Instance.Class);
+        cut.MarkupMatches("<ix-select-item id='test-select-item' class='custom-class'></ix-select-item>");
+    }
+
+    [Fact]
+    public void StylePropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.Style, "color: red;"));
+
+        // Assert
+        Assert.Equal("color: red;", cut.Instance.Style);
+        cut.MarkupMatches("<ix-select-item id='test-select-item' style='color: red;'></ix-select-item>");
+    }
+
+    [Fact]
+    public async Task ItemClickEventIsTriggeredCorrectly()
+    {
+        // Arrange
+        string? clickedItem = null;
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "test-select-item")
+            .Add(p => p.ItemClickEvent, EventCallback.Factory.Create<string>(this, (item) => clickedItem = item)));
+
+        // Act
+        cut.Instance.ItemClicked("Item Label");
+
+        // Assert
+        Assert.Equal("Item Label", clickedItem);
+    }
+
+    [Fact]
+    public void CompleteSelectItemRendersCorrectly()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<SelectItem>(parameters => parameters
+            .Add(p => p.Id, "selectItem1")
+            .Add(p => p.Label, "Item 1")
+            .Add(p => p.Value, "1")
+            .Add(p => p.Selected, true)
+            .Add(p => p.Class, "custom-class")
+            .Add(p => p.Style, "margin-top: 5px;"));
+
+        // Assert
+        cut.MarkupMatches("<ix-select-item id='selectItem1' label='Item 1' value='1' selected " +
+                         "style='margin-top: 5px;' class='custom-class'></ix-select-item>");
+    }
+
+    [Fact]
+    public void SelectItemRendersWithinSelect()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "parent-select")
+            .Add(p => p.Value, "1")
+            .Add(p => p.ChildContent, builder =>
+            {
+                builder.OpenComponent<SelectItem>(0);
+                builder.AddAttribute(1, "Id", "selectItem1");
+                builder.AddAttribute(2, "Label", "Item 1");
+                builder.AddAttribute(3, "Value", "1");
+                builder.CloseComponent();
+            }));
+
+        // Assert
+        cut.MarkupMatches("<ix-select id='parent-select' value='1' " +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single'" +
+                          "i-1-8n-no-matches='No matches'>" +
+                          "<ix-select-item id='selectItem1' label='Item 1' value='1'></ix-select-item>" +
+                          "</ix-select>");
+    }
+}

--- a/SiemensIXBlazor.Tests/Select/SelectTest.cs
+++ b/SiemensIXBlazor.Tests/Select/SelectTest.cs
@@ -1,0 +1,284 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.Select;
+using System.Text.Json;
+
+namespace SiemensIXBlazor.Tests.Select;
+
+public class SelectTests : TestContextBase
+{
+    [Fact]
+    public void ComponentRendersWithoutCrashing()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "1"));
+
+        // Assert
+        cut.MarkupMatches("<ix-select id='test-select' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' " +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void IdPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "custom-id")
+            .Add(p => p.Value, "1"));
+
+        // Assert
+        Assert.Equal("custom-id", cut.Instance.Id);
+        cut.MarkupMatches("<ix-select id='custom-id' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' " +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void AllowClearPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.AllowClear, true));
+
+        // Assert
+        Assert.True(cut.Instance.AllowClear);
+        cut.MarkupMatches("<ix-select id='test-select' allow-clear " +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single'" +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void ModePropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "1")
+            .Add(p => p.Mode, SelectMode.Multiple));
+
+        // Assert
+        Assert.Equal(SelectMode.Multiple, cut.Instance.Mode);
+        cut.MarkupMatches("<ix-select id='test-select' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='multiple' " +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void ValuePropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "testValue"));
+
+        // Assert
+        Assert.Equal("testValue", cut.Instance.Value);
+        cut.MarkupMatches("<ix-select id='test-select' value='testValue'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single'" +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void ClassPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "1")
+            .Add(p => p.Class, "ix-warning"));
+
+        // Assert
+        Assert.Equal("ix-warning", cut.Instance.Class);
+        cut.MarkupMatches("<ix-select id='test-select' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' class='ix-warning' " +
+                          "i-1-8n-no-matches='No matches'></ix-select>");
+    }
+
+    [Fact]
+    public void WarningTextPropertyIsSetCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "1")
+            .Add(p => p.WarningText, "This is a warning text"));
+
+        // Assert
+        Assert.Equal("This is a warning text", cut.Instance.WarningText);
+        cut.MarkupMatches("<ix-select id='test-select' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' " +
+                          "i-1-8n-no-matches='No matches' " +
+                          "warning-text='This is a warning text'></ix-select>");
+    }
+
+    [Fact]
+    public void ChildContentIsRenderedCorrectly()
+    {
+        // Arrange
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.Value, "1")
+            .Add(p => p.ChildContent, builder =>
+            {
+                builder.OpenComponent<SelectItem>(0);
+                builder.AddAttribute(1, "Id", "selectItem1");
+                builder.AddAttribute(2, "Label", "Item 1");
+                builder.AddAttribute(3, "Value", "1");
+                builder.CloseComponent();
+            }));
+
+        // Assert
+        cut.MarkupMatches("<ix-select id='test-select' value='1'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' " +
+                          "i-1-8n-no-matches='No matches'>" +
+                          "<ix-select-item id='selectItem1' label='Item 1' value='1'></ix-select-item>" +
+                          "</ix-select>");
+    }
+
+    [Fact]
+    public async Task AddItemEventIsTriggeredCorrectly()
+    {
+        // Arrange
+        string? addedItem = null;
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.AddItemEvent, EventCallback.Factory.Create<string>(this, (item) => addedItem = item)));
+
+        // Act
+        await cut.Instance.AddItemChanged("New Item");
+
+        // Assert
+        Assert.Equal("New Item", addedItem);
+    }
+
+    [Fact]
+    public async Task ValueChangeEventIsTriggeredCorrectlyWithString()
+    {
+        // Arrange
+        string? changedValue = null;
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<dynamic>(this, (value) => changedValue = value)));
+
+        // Act
+        var jsonElement = JsonDocument.Parse("\"Option 1\"").RootElement;
+        await cut.Instance.ValueChanged(jsonElement);
+
+        // Assert
+        Assert.Equal("Option 1", changedValue);
+    }
+
+    [Fact]
+    public async Task ValueChangeEventIsTriggeredCorrectlyWithArray()
+    {
+        // Arrange
+        string[]? changedValues = null;
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<dynamic>(this, (value) => changedValues = value)));
+
+        // Act
+        var jsonElement = JsonDocument.Parse("[\"Option 1\", \"Option 2\"]").RootElement;
+        await cut.Instance.ValueChanged(jsonElement);
+
+        // Assert
+        Assert.NotNull(changedValues);
+        Assert.Equal(2, changedValues.Length);
+        Assert.Equal("Option 1", changedValues[0]);
+        Assert.Equal("Option 2", changedValues[1]);
+    }
+
+    [Fact]
+    public async Task InputChangeEventIsTriggeredCorrectly()
+    {
+        // Arrange
+        string? changedInput = null;
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.InputChangeEvent, EventCallback.Factory.Create<string>(this, (input) => changedInput = input)));
+
+        // Act
+        await cut.Instance.InputChanged("New Input");
+
+        // Assert
+        Assert.Equal("New Input", changedInput);
+    }
+
+    [Fact]
+    public async Task BlurEventIsTriggeredCorrectly()
+    {
+        // Arrange
+        bool blurTriggered = false;
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "test-select")
+            .Add(p => p.BlurEvent, EventCallback.Factory.Create<object>(this, (_) => blurTriggered = true)));
+
+        // Act
+        await cut.Instance.Blurred();
+
+        // Assert
+        Assert.True(blurTriggered);
+    }
+
+    [Fact]
+    public void ComplexSelectComponentRendersCorrectly()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<Components.Select>(parameters => parameters
+            .Add(p => p.Id, "valid-select")
+            .Add(p => p.Class, "ix-warning")
+            .Add(p => p.Mode, SelectMode.Single)
+            .Add(p => p.Value, "2")
+            .Add(p => p.ValidText, "Your selection is correct!")
+            .Add(p => p.InfoText, "This is an info text")
+            .Add(p => p.WarningText, "This is a warning text")
+            .Add(p => p.ChildContent, builder =>
+            {
+                builder.OpenComponent<SelectItem>(0);
+                builder.AddAttribute(1, "Id", "selectItem1");
+                builder.AddAttribute(2, "Label", "Item 1");
+                builder.AddAttribute(3, "Value", "1");
+                builder.CloseComponent();
+
+                builder.OpenComponent<SelectItem>(4);
+                builder.AddAttribute(5, "Id", "selectItem2");
+                builder.AddAttribute(6, "Label", "Item 2");
+                builder.AddAttribute(7, "Value", "2");
+                builder.CloseComponent();
+            }));
+
+        // Assert
+        cut.MarkupMatches("<ix-select id='valid-select' value='2'" +
+                          "i-1-8n-placeholder='Select an option' i-1-8n-placeholder-editable='Type of select option' " +
+                          "i-1-8n-select-list-header='Please select an option' mode='single' " +
+                          "class='ix-warning' i-1-8n-no-matches='No matches' " +
+                          " info-text='This is an info text' valid-text='Your selection is correct!' " +
+                          "warning-text='This is a warning text'>" +
+                          "<ix-select-item id='selectItem1' label='Item 1' value='1'></ix-select-item>" +
+                          "<ix-select-item id='selectItem2' label='Item 2' value='2'></ix-select-item>" +
+                          "</ix-select>");
+    }
+}
+

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
@@ -29,5 +29,7 @@
 				  min-date="@MinDate"
 				  range="@Range"
 				  to="@To"
+				  week-start-index="@WeekStartIndex"
+				  locale="@Locale"
 				  disabled="@Disabled">
 </ix-date-dropdown>

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
@@ -20,75 +20,79 @@ namespace SiemensIXBlazor.Components;
 
 public partial class DateDropdown
 {
-	private BaseInterop _interop = null!;
-	private Lazy<Task<IJSObjectReference>>? _moduleTask;
+    private BaseInterop _interop = null!;
+    private Lazy<Task<IJSObjectReference>>? _moduleTask;
 
-	[Parameter, EditorRequired]
-	public string Id { get; set; } = string.Empty;
-	[Parameter]
-	public bool CustomRangeAllowed { get; set; } = true;
-	[Parameter]
-	public string DateRangeId { get; set; } = "custom";
-	[Parameter]
-	public EventCallback<string> DateRangeIdChanged { get; set; }
-	[Parameter]
-	public DateDropdownOption[]? DateRangeOptions { get; set; }
-	[Parameter]
-	public string Format { get; set; } = "yyyy/LL/dd";
-	[Parameter]
-	public string? From { get; set; }
-	[Parameter]
-	public string I18NCustomItem { get; set; } = "Custom...";
-	[Parameter]
-	public string I18NDone { get; set; } = "Done";
-	[Parameter]
-	public string I18NNoRange { get; set; } = "No range set";
-	[Parameter]
-	public string? MaxDate { get; set; }
-	[Parameter]
-	public string? MinDate { get; set; }
-	[Parameter]
-	public bool Range { get; set; } = true;
-	[Parameter]
-	public string? To { get; set; }
-	[Parameter]
-	public bool Disabled { get; set; } = false;
-	[Parameter]
-	public EventCallback<DateDropdownResponse> DateRangeChangeEvent { get; set; }
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+    [Parameter]
+    public bool CustomRangeAllowed { get; set; } = true;
+    [Parameter]
+    public string DateRangeId { get; set; } = "custom";
+    [Parameter]
+    public EventCallback<string> DateRangeIdChanged { get; set; }
+    [Parameter]
+    public DateDropdownOption[]? DateRangeOptions { get; set; }
+    [Parameter]
+    public string Format { get; set; } = "yyyy/LL/dd";
+    [Parameter]
+    public string? From { get; set; }
+    [Parameter]
+    public string I18NCustomItem { get; set; } = "Custom...";
+    [Parameter]
+    public string I18NDone { get; set; } = "Done";
+    [Parameter]
+    public string I18NNoRange { get; set; } = "No range set";
+    [Parameter]
+    public string? MaxDate { get; set; }
+    [Parameter]
+    public string? MinDate { get; set; }
+    [Parameter]
+    public bool Range { get; set; } = true;
+    [Parameter]
+    public string? To { get; set; }
+    [Parameter]
+    public bool Disabled { get; set; } = false;
+    [Parameter]
+    public string? Locale { get; set; }
+    [Parameter]
+    public int? WeekStartIndex { get; set; } = 0;
+    [Parameter]
+    public EventCallback<DateDropdownResponse> DateRangeChangeEvent { get; set; }
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-		if (firstRender)
-		{
-			await InitialParameterAsync("setDateRangeOptions", DateRangeOptions);
-			_interop = new BaseInterop(JsRuntime);
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await InitialParameterAsync("setDateRangeOptions", DateRangeOptions);
+            _interop = new BaseInterop(JsRuntime);
 
-			await _interop.AddEventListener(this, Id, "dateRangeChange", "DateRangeChange");
-		}
-	}
+            await _interop.AddEventListener(this, Id, "dateRangeChange", "DateRangeChange");
+        }
+    }
 
-	private async Task InitialParameterAsync(string functionName, object? param)
-	{
-		_moduleTask = new Lazy<Task<IJSObjectReference>>(() => JsRuntime.InvokeAsync<IJSObjectReference>(
-			"import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/dateDropdownInterop.js").AsTask());
+    private async Task InitialParameterAsync(string functionName, object? param)
+    {
+        _moduleTask = new Lazy<Task<IJSObjectReference>>(() => JsRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/dateDropdownInterop.js").AsTask());
 
-		var dateRangeOptions = JsonConvert.SerializeObject(param, new JsonSerializerSettings
-		{
-			ContractResolver = new CamelCasePropertyNamesContractResolver()
-		});
+        var dateRangeOptions = JsonConvert.SerializeObject(param, new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        });
 
-		var module = await _moduleTask.Value;
-		if (module != null)
-			await module.InvokeVoidAsync(functionName, Id, dateRangeOptions);
-	}
+        var module = await _moduleTask.Value;
+        if (module != null)
+            await module.InvokeVoidAsync(functionName, Id, dateRangeOptions);
+    }
 
-	[JSInvokable]
-	public async void DateRangeChange(JsonElement data)
-	{
-		var jsonDataText = data.GetRawText();
-		var jsonData = JObject.Parse(jsonDataText)
-			.ToObject<DateDropdownResponse>();
+    [JSInvokable]
+    public async void DateRangeChange(JsonElement data)
+    {
+        var jsonDataText = data.GetRawText();
+        var jsonData = JObject.Parse(jsonDataText)
+            .ToObject<DateDropdownResponse>();
 
-		await DateRangeChangeEvent.InvokeAsync(jsonData);
-	}
+        await DateRangeChangeEvent.InvokeAsync(jsonData);
+    }
 }

--- a/SiemensIXBlazor/Components/Select/Select.razor
+++ b/SiemensIXBlazor/Components/Select/Select.razor
@@ -7,18 +7,37 @@
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------
 *@
-
 @using Microsoft.JSInterop;
 @using SiemensIXBlazor.Enums.Select;
 @using SiemensIXBlazor.Helpers;
 @inject IJSRuntime JSRuntime
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
-
-<ix-select @attributes="UserAttributes" value="@Value" allow-clear="@AllowClear" disabled="@Disabled"
-    editable="@Editable" i-1-8n-placeholder="@i18nPlaceholder" i-1-8n-placeholder-editable="@i18nPlaceholderEditable"
-    i-1-8n-select-list-header="@i18nSelectListHeader" mode="@(EnumParser<SelectMode>.EnumToString(Mode))" id="@Id"
-    readonly="@Readonly" style="@Style" class="@Class" hide-list-header="@HideListHeader"
-    i-1-8n-no-matches="@I18NNoMatches">
+<ix-select @attributes="UserAttributes"
+           value="@Value"
+           allow-clear="@AllowClear"
+           disabled="@Disabled"
+           editable="@Editable"
+           i-1-8n-placeholder="@i18nPlaceholder"
+           i-1-8n-placeholder-editable="@i18nPlaceholderEditable"
+           i-1-8n-select-list-header="@i18nSelectListHeader"
+           mode="@(EnumParser<SelectMode>.EnumToString(Mode))"
+           id="@Id"
+           readonly="@Readonly"
+           style="@Style"
+           class="@Class"
+           hide-list-header="@HideListHeader"
+           i-1-8n-no-matches="@I18NNoMatches"
+           dropdown-max-width="@DropdownMaxWidth"
+           dropdown-width="@DropdownWidth"
+           helper-text="@HelperText"
+           info-text="@InfoText"
+           invalid-text="@InvalidText"
+           valid-text="@ValidText"
+           warning-text="@WarningText"
+           label="@Label"
+           name="@Name"
+           required="@Required"
+           show-text-as-tooltip="@ShowTextAsTooltip">
     @ChildContent
 </ix-select>

--- a/SiemensIXBlazor/Components/Select/Select.razor.cs
+++ b/SiemensIXBlazor/Components/Select/Select.razor.cs
@@ -5,98 +5,126 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-//  -----------------------------------------------------------------------
-
-using System.Text.Json;
+// -----------------------------------------------------------------------
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using SiemensIXBlazor.Enums.Select;
 using SiemensIXBlazor.Interops;
+using System.Text.Json;
 
-namespace SiemensIXBlazor.Components
+namespace SiemensIXBlazor.Components;
+
+public partial class Select
 {
-    public partial class Select
-	{
-		[Parameter, EditorRequired]
-		public string Id { get; set; } = string.Empty;
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
-		[Parameter]
-		public bool AllowClear { get; set; } = false;
-		[Parameter]
-		public bool Disabled { get; set; } = false;
-		[Parameter]
-		public bool Editable { get; set; } = false;
-		[Parameter]
-		public string i18nPlaceholder { get; set; } = "Select an option";
-		[Parameter]
-		public string i18nPlaceholderEditable { get; set; } = "Type of select option";
-		[Parameter]
-		public string i18nSelectListHeader { get; set; } = "Please select an option";
-		[Parameter]
-		public SelectMode Mode { get; set; } = SelectMode.Single;
-		[Parameter]
-		public bool Readonly { get; set; } = false;
-		[Parameter]
-		public dynamic? Value { get; set; }
-		[Parameter]
-		public bool HideListHeader { get; set; } = false;
-		[Parameter]
-		public string I18NNoMatches { get; set; } = "No matches";
-		[Parameter]
-		public EventCallback<string> AddItemEvent { get; set; }
-        [Parameter]
-        public EventCallback<dynamic> ValueChangeEvent { get; set; }
-        [Parameter]
-        public EventCallback<string> InputChangeEvent { get; set; }
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+    [Parameter]
+    public bool AllowClear { get; set; } = false;
+    [Parameter]
+    public bool Disabled { get; set; } = false;
+    [Parameter]
+    public bool Editable { get; set; } = false;
+    [Parameter]
+    public string i18nPlaceholder { get; set; } = "Select an option";
+    [Parameter]
+    public string i18nPlaceholderEditable { get; set; } = "Type of select option";
+    [Parameter]
+    public string i18nSelectListHeader { get; set; } = "Please select an option";
+    [Parameter]
+    public SelectMode Mode { get; set; } = SelectMode.Single;
+    [Parameter]
+    public bool Readonly { get; set; } = false;
+    [Parameter]
+    public string? Value { get; set; }
+    [Parameter]
+    public bool HideListHeader { get; set; } = false;
+    [Parameter]
+    public string I18NNoMatches { get; set; } = "No matches";
+    [Parameter]
+    public string? DropdownMaxWidth { get; set; }
+    [Parameter]
+    public string? DropdownWidth { get; set; }
+    [Parameter]
+    public string? HelperText { get; set; }
+    [Parameter]
+    public string? InfoText { get; set; }
+    [Parameter]
+    public string? InvalidText { get; set; }
+    [Parameter]
+    public string? ValidText { get; set; }
+    [Parameter]
+    public string? WarningText { get; set; }
+    [Parameter]
+    public string? Label { get; set; }
+    [Parameter]
+    public string? Name { get; set; }
+    [Parameter]
+    public bool Required { get; set; } = false;
+    [Parameter]
+    public bool ShowTextAsTooltip { get; set; } = false;
+    [Parameter]
+    public EventCallback<string> AddItemEvent { get; set; }
+    [Parameter]
+    public EventCallback<dynamic> ValueChangeEvent { get; set; }
+    [Parameter]
+    public EventCallback<string> InputChangeEvent { get; set; }
+    [Parameter]
+    public EventCallback<object> BlurEvent { get; set; }
 
-        private BaseInterop _interop;
+    private BaseInterop? _interop;
 
-        protected async override Task OnAfterRenderAsync(bool firstRender)
+    protected async override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
         {
-            if (firstRender)
-            {
-                _interop = new(JSRuntime);
-
-                await _interop.AddEventListener(this, Id, "addItem", "AddItemChanged");
-                await _interop.AddEventListener(this, Id, "valueChange", "ValueChanged");
-                await _interop.AddEventListener(this, Id, "inputChange", "InputChanged");
-            }
+            _interop = new(JSRuntime);
+            await _interop.AddEventListener(this, Id, "addItem", nameof(AddItemChanged));
+            await _interop.AddEventListener(this, Id, "valueChange", nameof(ValueChanged));
+            await _interop.AddEventListener(this, Id, "inputChange", nameof(InputChanged));
+            await _interop.AddEventListener(this, Id, "ixBlur", nameof(Blurred));
         }
+    }
 
-        [JSInvokable]
-		public async void AddItemChanged(string label)
-		{
-			await AddItemEvent.InvokeAsync(label);
-		}
+    [JSInvokable]
+    public async Task AddItemChanged(string label)
+    {
+        if (AddItemEvent.HasDelegate)
+        {
+            await AddItemEvent.InvokeAsync(label);
+        }
+    }
 
-        [JSInvokable]
-        public async void InputChanged(string input)
+    [JSInvokable]
+    public async Task InputChanged(string input)
+    {
+        if (InputChangeEvent.HasDelegate)
         {
             await InputChangeEvent.InvokeAsync(input);
         }
+    }
 
-        [JSInvokable]
-        public async void ValueChanged(dynamic labels)
+    [JSInvokable]
+    public async Task ValueChanged(JsonElement labels)
+    {
+        if (labels.ValueKind == JsonValueKind.String)
         {
-			if(labels is string)
-			{
-                await ValueChangeEvent.InvokeAsync(labels);
-            }
-			else if(labels is JsonElement)
-			{
-				JsonElement jsonText = labels;
+            await ValueChangeEvent.InvokeAsync(labels.GetString());
+        }
+        else if (labels.ValueKind == JsonValueKind.Array)
+        {
+            var labelArray = labels.Deserialize<string[]>();
+            await ValueChangeEvent.InvokeAsync(labelArray);
+        }
+    }
 
-				if (jsonText.ValueKind == JsonValueKind.Array) {
-					string[] labelArray = jsonText.Deserialize<string[]>()!;
-					await ValueChangeEvent.InvokeAsync(labelArray);
-				} else
-				{
-                    await ValueChangeEvent.InvokeAsync(jsonText.GetString());
-                }
-            }
-            
+    [JSInvokable]
+    public async Task Blurred()
+    {
+        if (BlurEvent.HasDelegate)
+        {
+            await BlurEvent.InvokeAsync(null);
         }
     }
 }
-


### PR DESCRIPTION
## 💡 What is the current behavior?

- The `DateDropdown` component does not support specifying the starting day of the week (`WeekStartIndex`) or localization settings (`Locale`), which were introduced in the latest IX version.
- The `Select` component lacks several properties, and in the latest version of IX, it is a form-ready component.
- `Select` and `SelectItem` components lack tests.

## 🆕 What is the new behavior?

- Added new properties to `DateDropdown`:
  - `WeekStartIndex`
  - `Locale`
  
- Added new properties to `Select` component:
  - `Name`
  - `Required`
  - `ShowTextAsTooltip`
  - `InfoText`
  - `InvalidText`
  - `Label`
  - `ValidText`
  - `WarningText`
  - `HelperText`
  - `DropdownWidth`
  - `DropdownMaxWidth`
 
- Added `ixBlur` event support to `Select` component

- Added tests for `Select` and `SelectItem`

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)
## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
