### PR TITLE
Add New Properties to DateDropdown and ExpandingSearch

### DIFF
--- a/SiemensIXBlazor.Tests/DateDropdownTest.cs
+++ b/SiemensIXBlazor.Tests/DateDropdownTest.cs
@@ -10,8 +10,7 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
-using SiemensIXBlazor.Components.BasicNavigation;
-using SiemensIXBlazor.Enums.BasicNavigation;
+using SiemensIXBlazor.Enums.DateDropdown;
 using SiemensIXBlazor.Objects.DateDropdown;
 using System.Text.Json;
 
@@ -27,7 +26,7 @@ public class DateDropdownTest : TestContextBase
 
         // Assert
         cut.MarkupMatches(@"
-                <ix-date-dropdown id='' custom-range-allowed='' week-start-index='0' date-range-id='custom' format='yyyy/LL/dd' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' range=''></ix-date-dropdown>
+                <ix-date-dropdown id='' variant='primary' custom-range-allowed='' week-start-index='0' date-range-id='custom' format='yyyy/LL/dd' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' range=''></ix-date-dropdown>
             ");
     }
 
@@ -58,11 +57,16 @@ public class DateDropdownTest : TestContextBase
             .Add(p => p.Locale, "en")
             .Add(p => p.WeekStartIndex, 2)
             .Add(p => p.DateRangeChangeEvent, dateRangeChangeEvent)
-            .Add(p => p.Disabled, true));
+            .Add(p => p.Disabled, true)
+            .Add(p => p.Ghost, true)
+            .Add(p => p.Loading, true)
+            .Add(p => p.Outline, true)
+            .Add(p => p.Variant, DateDropdownVariant.secondary)
+            );
 
         // Assert
         cut.MarkupMatches(@"
-                <ix-date-dropdown id='testId' locale='en' week-start-index='2' custom-range-allowed='' date-range-id='custom' format='yyyy/LL/dd' from='2022/01/01' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' max-date='2022/12/31' min-date='2022/01/01' range='' to='2022/12/31' disabled></ix-date-dropdown>
+                <ix-date-dropdown id='testId' outline ghost loading variant='secondary' locale='en' week-start-index='2' custom-range-allowed='' date-range-id='custom' format='yyyy/LL/dd' from='2022/01/01' i18n-custom-item='Custom...' i18n-done='Done' i18n-no-range='No range set' max-date='2022/12/31' min-date='2022/01/01' range='' to='2022/12/31' disabled></ix-date-dropdown>
             ");
     }
 

--- a/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
+++ b/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
@@ -10,6 +10,7 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.ExpandingSearch;
 
 namespace SiemensIXBlazor.Tests;
 
@@ -23,11 +24,16 @@ public class ExpandingSearchTest : TestContextBase
             .Add(p => p.Id, "testId")
             .Add(p => p.Icon, "testIcon")
             .Add(p => p.Placeholder, "testPlaceholder")
-            .Add(p => p.Value, "testValue"));
+            .Add(p => p.Value, "testValue")
+            .Add(p => p.FullWidth, true)
+            .Add(p => p.Outline, true)
+            .Add(p => p.Ghost, false)
+            .Add(p => p.Variant, ExpandingSearchVariant.secondary)
+            );
 
         // Assert
         cut.MarkupMatches(
-            "<ix-expanding-search placeholder=\"testPlaceholder\" icon=\"testIcon\" id=\"testId\" value=\"testValue\"></ix-expanding-search>");
+            "<ix-expanding-search placeholder=\"testPlaceholder\" icon=\"testIcon\" id=\"testId\" value=\"testValue\" full-width outline variant='secondary'></ix-expanding-search>");
     }
 
     [Fact]

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
@@ -9,27 +9,32 @@
 *@
 
 @namespace SiemensIXBlazor.Components
-@using Microsoft.JSInterop
-
+@using Microsoft.JSInterop;
+@using SiemensIXBlazor.Helpers;
+@using SiemensIXBlazor.Enums.DateDropdown;
 @inject IJSRuntime JsRuntime
 @inherits IXBaseComponent
 
 <ix-date-dropdown @attributes="UserAttributes"
-				  style="@Style"
-				  class="@Class"
-				  id="@Id"
-				  custom-range-allowed="@CustomRangeAllowed"
-				  date-range-id="@DateRangeId"
-				  format="@Format"
-				  from="@From"
-				  i18n-custom-item="@I18NCustomItem"
-				  i18n-done="@I18NDone"
-				  i18n-no-range="@I18NNoRange"
-				  max-date="@MaxDate"
-				  min-date="@MinDate"
-				  range="@Range"
-				  to="@To"
-				  week-start-index="@WeekStartIndex"
-				  locale="@Locale"
-				  disabled="@Disabled">
+                  style="@Style"
+                  class="@Class"
+                  id="@Id"
+                  custom-range-allowed="@CustomRangeAllowed"
+                  date-range-id="@DateRangeId"
+                  format="@Format"
+                  from="@From"
+                  i18n-custom-item="@I18NCustomItem"
+                  i18n-done="@I18NDone"
+                  i18n-no-range="@I18NNoRange"
+                  max-date="@MaxDate"
+                  min-date="@MinDate"
+                  range="@Range"
+                  to="@To"
+                  week-start-index="@WeekStartIndex"
+                  locale="@Locale"
+                  disabled="@Disabled"
+                  outline="@Outline"
+                  ghost="@Ghost"
+                  loading="@Loading"
+                  variant="@(EnumParser<DateDropdownVariant>.EnumToString(Variant))">
 </ix-date-dropdown>

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
@@ -12,6 +12,7 @@ using Microsoft.JSInterop;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using SiemensIXBlazor.Enums.DateDropdown;
 using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects.DateDropdown;
 using System.Text.Json;
@@ -57,6 +58,14 @@ public partial class DateDropdown
     public string? Locale { get; set; }
     [Parameter]
     public int? WeekStartIndex { get; set; } = 0;
+    [Parameter]
+    public bool Ghost { get; set; } = false;
+    [Parameter]
+    public bool Outline { get; set; } = false;
+    [Parameter]
+    public bool Loading { get; set; } = false;
+    [Parameter]
+    public DateDropdownVariant Variant { get; set; } = DateDropdownVariant.primary;
     [Parameter]
     public EventCallback<DateDropdownResponse> DateRangeChangeEvent { get; set; }
 

--- a/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor
+++ b/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor
@@ -10,14 +10,19 @@
 
 @using Microsoft.JSInterop;
 @inject IJSRuntime JSRuntime
+@using SiemensIXBlazor.Helpers;
+@using SiemensIXBlazor.Enums.ExpandingSearch;
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
-
-<ix-expanding-search
-@attributes="UserAttributes"
-placeholder="@Placeholder"
-icon="@Icon"
-id="@Id"
-value="@Value"
-style="@Style"
-class="@Class"></ix-expanding-search>
+<ix-expanding-search @attributes="UserAttributes"
+                     placeholder="@Placeholder"
+                     icon="@Icon"
+                     id="@Id"
+                     value="@Value"
+                     style="@Style"
+                     class="@Class"
+                     full-width="@FullWidth"
+                     outline="@Outline"
+                     ghost="@Ghost"
+                     variant="@(EnumParser<ExpandingSearchVariant>.EnumToString(Variant))">
+</ix-expanding-search>

--- a/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor.cs
+++ b/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor.cs
@@ -9,6 +9,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using SiemensIXBlazor.Enums.ExpandingSearch;
 using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components
@@ -24,9 +25,17 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string Value { get; set; } = string.Empty;
         [Parameter]
+        public bool Ghost { get; set; } = true;
+        [Parameter]
+        public bool Outline { get; set; } = false;
+        [Parameter]
+        public bool FullWidth { get; set; } = false;
+        [Parameter]
+        public ExpandingSearchVariant Variant { get; set; } = ExpandingSearchVariant.primary;
+        [Parameter]
         public EventCallback<string> ValueChangedEvent { get; set; }
 
-        private BaseInterop _interop;
+        private BaseInterop? _interop;
 
         protected async override Task OnAfterRenderAsync(bool firstRender)
         {

--- a/SiemensIXBlazor/Enums/DateDropdown/DateDropdownVariant.cs
+++ b/SiemensIXBlazor/Enums/DateDropdown/DateDropdownVariant.cs
@@ -1,0 +1,16 @@
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.DateDropdown;
+public enum DateDropdownVariant
+{
+    primary,
+    secondary,
+    danger
+}

--- a/SiemensIXBlazor/Enums/ExpandingSearch/ExpandingSearchVariant.cs
+++ b/SiemensIXBlazor/Enums/ExpandingSearch/ExpandingSearchVariant.cs
@@ -1,0 +1,16 @@
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.ExpandingSearch;
+public enum ExpandingSearchVariant
+{
+    primary,
+    secondary,
+    danger
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

The `DateDropdown` and `ExpandingSearch` components do not support the properties introduced in IX version 2.7.0.

## 🆕 What is the new behavior?

To align with IX version 2.7.0, the following properties have been added:

- **DateDropdown**:
  - `Outline`
  - `Ghost`
  - `Loading`
  - `Variant`

- **ExpandingSearch**:
  - `Outline`
  - `Ghost`
  - `Variant`
  - `FullWidth`

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

