### PR TITLE
Refactor color properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,7 +1143,7 @@ private void CloseModal()
 ## Pill
 
 ```razor
-<Pill Variant="PillVariant.custom" Color="white" Background="purple">
+<Pill Variant="PillVariant.custom" PillColor="white" Background="purple">
     Label
 </Pill>
 ```

--- a/SiemensIXBlazor.Tests/ChipTests.cs
+++ b/SiemensIXBlazor.Tests/ChipTests.cs
@@ -23,14 +23,14 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.Active, true);
                 parameters.Add(p => p.Background, "testBackground");
                 parameters.Add(p => p.Closable, true);
-                parameters.Add(p => p.Color, "testColor");
+                parameters.Add(p => p.ChipColor, "testColor");
                 parameters.Add(p => p.Icon, "testIcon");
                 parameters.Add(p => p.Outline, true);
                 parameters.Add(p => p.Variant, Enums.Chip.ChipVariant.neutral);
             });
 
             // Assert
-            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" active=\"\" background=\"testBackground\" color=\"testColor\" icon=\"testIcon\" variant=\"neutral\"></ix-chip>");
+            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" active=\"\" background=\"testBackground\" chip-color=\"testColor\" icon=\"testIcon\" variant=\"neutral\"></ix-chip>");
         }
 
         [Fact]

--- a/SiemensIXBlazor.Tests/EventList/EventListItemTest.cs
+++ b/SiemensIXBlazor.Tests/EventList/EventListItemTest.cs
@@ -23,7 +23,7 @@ public class EventListItemTest : TestContextBase
             .Add(p => p.Id, "testId")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Chevron, true)
-            .Add(p => p.Color, "red")
+            .Add(p => p.ItemColor, "red")
             .Add(p => p.Disabled, false)
             .Add(p => p.Opacity, 1)
             .Add(p => p.Selected, true)
@@ -31,7 +31,7 @@ public class EventListItemTest : TestContextBase
 
         // Assert
         cut.MarkupMatches(
-            "<ix-event-list-item id=\"testId\" color=\"red\" chevron=\"\" opacity=\"1\" selected=\"\">Test content</ix-event-list-item>");
+            "<ix-event-list-item id=\"testId\" item-color=\"red\" chevron=\"\" opacity=\"1\" selected=\"\">Test content</ix-event-list-item>");
     }
 
     [Fact]

--- a/SiemensIXBlazor.Tests/PillTest.cs
+++ b/SiemensIXBlazor.Tests/PillTest.cs
@@ -9,7 +9,6 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using Xunit;
 using SiemensIXBlazor.Components;
 using SiemensIXBlazor.Enums.Pill;
 
@@ -18,27 +17,72 @@ namespace SiemensIXBlazor.Tests
     public class PillTests : TestContextBase
     {
         [Fact]
-        public void PillRendersCorrectly()
+        public void PillRendersWithAllParameters()
         {
-            // Arrange
-            var cut = RenderComponent<Pill>(
-                ("AlignLeft", true),
-                ("Background", "red"),
-                ("Color", "white"),
-                ("Icon", "testIcon"),
-                ("Outline", true),
-                ("Variant", PillVariant.primary),
-                ("ChildContent", (RenderFragment)(builder =>
+            // Arrange & Act
+            var cut = RenderComponent<Pill>(parameters =>
+            {
+                parameters.Add(p => p.AlignLeft, true);
+                parameters.Add(p => p.Background, "red");
+                parameters.Add(p => p.PillColor, "white");
+                parameters.Add(p => p.Icon, "testIcon");
+                parameters.Add(p => p.Outline, true);
+                parameters.Add(p => p.Variant, PillVariant.primary);
+                parameters.Add(p => p.ChildContent, builder =>
                 {
                     builder.OpenElement(0, "div");
                     builder.AddContent(1, "Test child content");
                     builder.CloseElement();
-                }))
-            );
+                });
+            });
 
             // Assert
-       
-            cut.MarkupMatches("<ix-pill align-left=\"\" background=\"red\" color=\"white\" icon=\"testIcon\" outline=\"\" variant=\"primary\"><div>Test child content</div></ix-pill>");
+            cut.MarkupMatches("<ix-pill align-left=\"\" background=\"red\" pill-color=\"white\" icon=\"testIcon\" outline=\"\" variant=\"primary\"><div>Test child content</div></ix-pill>");
+        }
+
+        [Fact]
+        public void PillRendersWithDefaultParameters()
+        {
+            // Act
+            var cut = RenderComponent<Pill>();
+
+            // Assert
+            cut.MarkupMatches("<ix-pill variant=\"primary\"></ix-pill>");
+        }
+
+        [Fact]
+        public void PillRendersChildContentOnly()
+        {
+            // Arrange
+            var content = "Simple Text";
+
+            // Act
+            var cut = RenderComponent<Pill>(parameters =>
+            {
+                parameters.Add(p => p.ChildContent, (RenderFragment)(builder =>
+                {
+                    builder.AddContent(0, content);
+                }));
+            });
+
+            // Assert
+            Assert.Contains(content, cut.Markup);
+        }
+
+        [Fact]
+        public void PillHasBooleanAttributes()
+        {
+            // Act
+            var cut = RenderComponent<Pill>(parameters =>
+            {
+                parameters.Add(p => p.AlignLeft, true);
+                parameters.Add(p => p.Outline, true);
+            });
+
+            // Assert
+            var element = cut.Find("ix-pill");
+            Assert.True(element.HasAttribute("align-left"));
+            Assert.True(element.HasAttribute("outline"));
         }
     }
 }

--- a/SiemensIXBlazor/Components/Chip/Chip.razor
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor
@@ -16,5 +16,5 @@
 @inject IJSRuntime JSRuntime
 
 <ix-chip @attributes="UserAttributes" id="@Id" closable="@Closable" outline="@Outline" active="@Active"
-    background="@Background" color="@Color" icon="@Icon" variant="@(EnumParser<ChipVariant>.EnumToString(Variant))"
+    background="@Background" chip-color="@ChipColor" icon="@Icon" variant="@(EnumParser<ChipVariant>.EnumToString(Variant))"
     style="@Style" class="@Class">@ChildContent</ix-chip>

--- a/SiemensIXBlazor/Components/Chip/Chip.razor.cs
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor.cs
@@ -27,7 +27,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool Closable { get; set; } = false;
         [Parameter]
-        public string? Color { get; set; }
+        public string? ChipColor { get; set; }
         [Parameter]
         public string? Icon { get; set; }
         [Parameter]

--- a/SiemensIXBlazor/Components/EventList/EventListItem.razor
+++ b/SiemensIXBlazor/Components/EventList/EventListItem.razor
@@ -16,7 +16,7 @@
 <ix-event-list-item
 @attributes="UserAttributes"
 id="@Id"
-color="@Color"
+item-color="@ItemColor"
 chevron="@Chevron"
 disabled="@Disabled"
 opacity="@Opacity"

--- a/SiemensIXBlazor/Components/EventList/EventListItem.razor.cs
+++ b/SiemensIXBlazor/Components/EventList/EventListItem.razor.cs
@@ -22,7 +22,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool? Chevron { get; set; }
         [Parameter]
-        public string? Color { get; set; }
+        public string? ItemColor { get; set; }
         [Parameter]
         public bool? Disabled { get; set; }
         [Parameter]

--- a/SiemensIXBlazor/Components/Pill/Pill.razor
+++ b/SiemensIXBlazor/Components/Pill/Pill.razor
@@ -13,7 +13,7 @@
 @using SiemensIXBlazor.Helpers;
 @inherits IXBaseComponent
 
-<ix-pill @attributes="UserAttributes" variant="@(EnumParser<PillVariant>.EnumToString(Variant))" color="@Color"
+<ix-pill @attributes="UserAttributes" variant="@(EnumParser<PillVariant>.EnumToString(Variant))" pill-color="@PillColor"
     background="@Background" align-left="@AlignLeft" icon="@Icon" outline="@Outline" style="@Style" class="@Class">
     @ChildContent
 </ix-pill>

--- a/SiemensIXBlazor/Components/Pill/Pill.razor.cs
+++ b/SiemensIXBlazor/Components/Pill/Pill.razor.cs
@@ -7,7 +7,6 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using System;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Enums.Pill;
 
@@ -22,7 +21,7 @@ namespace SiemensIXBlazor.Components
 		[Parameter]
 		public string? Background { get; set; }
 		[Parameter]
-		public string? Color { get; set; }
+		public string? PillColor { get; set; }
 		[Parameter]
 		public string? Icon { get; set; }
 		[Parameter]


### PR DESCRIPTION
## 💡 What is the current behavior?

The color prop is currently used across multiple components (ix-chip, ix-event-list, and ix-pill), but the naming does not follow the new naming conventions. Corresponding unit tests also rely on the old prop names.

## 🆕 What is the new behavior?

- Renamed color props to follow the new naming convention:

  - ix-chip: color → chip-color

  - ix-event-list: color → item-color

  - ix-pill: color → pill-color

- Updated corresponding component tests to use the new prop names

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
