### PR TITLE
Refactor card variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
               Notification="3"
               Heading="Heading content"
               SubHeading="Subheading"
-              Variant="PushCardVariant.notification"></PushCard>
+              Variant="PushCardVariant.outline"></PushCard>
     <PushCard Icon="bulb"
               Notification="1"
               Heading="Heading content"
@@ -553,7 +553,7 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
         Notification="3"
         Heading="Heading content"
         SubHeading="Subheading"
-        Variant="PushCardVariant.notification"></PushCard>
+        Variant="PushCardVariant.outline"></PushCard>
 ```
 
 ## Action Card
@@ -563,7 +563,7 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
       Icon="refresh"
       Heading="Scan for new devices"
       SubHeading="Secondary text"
-      Variant="PushCardVariant.notification"
+      Variant="PushCardVariant.filled"
 ></ActionCard>
 ```
 

--- a/SiemensIXBlazor.Tests/ActionCardTests.cs
+++ b/SiemensIXBlazor.Tests/ActionCardTests.cs
@@ -22,7 +22,7 @@ namespace SiemensIXBlazor.Tests
             var cut = RenderComponent<ActionCard>();
 
             // Assert
-            cut.MarkupMatches("<ix-action-card variant='insight'></ix-action-card>");
+            cut.MarkupMatches("<ix-action-card variant='outline'></ix-action-card>");
         }
 
         [Fact]
@@ -69,10 +69,10 @@ namespace SiemensIXBlazor.Tests
         public void VariantPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Variant, PushCardVariant.insight));
+            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Variant, PushCardVariant.outline));
 
             // Assert
-            Assert.Equal(PushCardVariant.insight, cut.Instance.Variant);
+            Assert.Equal(PushCardVariant.outline, cut.Instance.Variant);
         }
     }
 }

--- a/SiemensIXBlazor.Tests/CardTests.cs
+++ b/SiemensIXBlazor.Tests/CardTests.cs
@@ -42,7 +42,7 @@ namespace SiemensIXBlazor.Tests
                 }));
 
             // Assert
-            cut.MarkupMatches("<ix-card variant=\"insight\">\r\n      <ix-card-content>Expected content</ix-card-content>\r\n    </ix-card>");
+            cut.MarkupMatches("<ix-card variant=\"outline\">\r\n      <ix-card-content>Expected content</ix-card-content>\r\n    </ix-card>");
         }
     }
 }

--- a/SiemensIXBlazor.Tests/Helper/EnumParserTests.cs
+++ b/SiemensIXBlazor.Tests/Helper/EnumParserTests.cs
@@ -7,7 +7,7 @@ namespace SiemensIXBlazor.Tests.Helpers
     {
         [Theory]
         [InlineData(PushCardVariant.alarm, "alarm")]
-        [InlineData(PushCardVariant.insight, "insight")]
+        [InlineData(PushCardVariant.outline, "outline")]
         public void EnumToString_ShouldReturnCorrectLowercaseString_ForValidEnum(PushCardVariant variant, string expected)
         {
             // Act

--- a/SiemensIXBlazor.Tests/PushCardTest.cs
+++ b/SiemensIXBlazor.Tests/PushCardTest.cs
@@ -26,12 +26,12 @@ namespace SiemensIXBlazor.Tests
                 ("Notification", "5"),
                 ("SubHeading", "Test SubHeading"),
                 ("Collapsed", true),
-                ("Variant", PushCardVariant.insight)
+                ("Variant", PushCardVariant.outline)
             );
 
             // Assert
         
-            cut.MarkupMatches("<ix-push-card heading=\"Test Heading\" icon=\"testIcon\" notification=\"5\" subheading=\"Test SubHeading\" collapsed=\"\" variant=\"insight\"></ix-push-card>");
+            cut.MarkupMatches("<ix-push-card heading=\"Test Heading\" icon=\"testIcon\" notification=\"5\" subheading=\"Test SubHeading\" collapsed=\"\" variant=\"outline\"></ix-push-card>");
         }
     }
 }

--- a/SiemensIXBlazor/Components/ActionCard/ActionCard.razor.cs
+++ b/SiemensIXBlazor/Components/ActionCard/ActionCard.razor.cs
@@ -39,7 +39,7 @@ namespace SiemensIXBlazor.Components
         /// Card variant
         /// </summary>
         [Parameter]
-        public PushCardVariant Variant { get; set; } = PushCardVariant.insight;
+        public PushCardVariant Variant { get; set; } = PushCardVariant.outline;
     }
 }
 

--- a/SiemensIXBlazor/Components/Card/Card.razor.cs
+++ b/SiemensIXBlazor/Components/Card/Card.razor.cs
@@ -17,7 +17,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool? Selected { get; set; }
         [Parameter]
-        public CardVariant Variant { get; set; } = CardVariant.insight;
+        public CardVariant Variant { get; set; } = CardVariant.outline;
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
     }

--- a/SiemensIXBlazor/Components/PushCard/PushCard.razor.cs
+++ b/SiemensIXBlazor/Components/PushCard/PushCard.razor.cs
@@ -41,7 +41,7 @@ namespace SiemensIXBlazor.Components
         /// Card variant
         /// </summary>
         [Parameter]
-        public PushCardVariant Variant { get; set; } = PushCardVariant.insight;
+        public PushCardVariant Variant { get; set; } = PushCardVariant.outline;
     }
 }
 

--- a/SiemensIXBlazor/Enums/Card/CardVariant.cs
+++ b/SiemensIXBlazor/Enums/Card/CardVariant.cs
@@ -14,9 +14,9 @@ namespace SiemensIXBlazor.Enums
         alarm,
         critical,
         info,
-        insight,
         neutral,
-        notification,
+        outline,
+        filled,
         primary,
         success,
         warning

--- a/SiemensIXBlazor/Enums/PushCard/PushCardVariant.cs
+++ b/SiemensIXBlazor/Enums/PushCard/PushCardVariant.cs
@@ -14,9 +14,9 @@ namespace SiemensIXBlazor.Enums.PushCard
 		alarm,
 		critical,
 		info,
-		insight,
 		neutral,
-		notification,
+		outline,
+		filled,
 		success,
 		warning
 	}


### PR DESCRIPTION
## 💡 What is the current behavior?

The insight and notification variants are currently used in ix-action-card, ix-card, and ix-push-card components. These variants have been removed in ix v3.0.0 and are no longer supported.

## 🆕 What is the new behavior?

- Replaced deprecated insight and notification variants with the new outline and filled variants in:
  - ix-action-card
  - ix-card
  - ix-push-card
  
- Updated corresponding component tests to use the new variant values
- Updated README examples to reflect these changes

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support
