### PR TITLE
feat: add TooltipText support and tests for Chip and Pill components

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ chart1.InitialChart(object1);
       Label="Chip with icon"
       Id="chip1"
       Closable="true"
+      TooltipText="Tooltip Text"
       ClosedEvent="@ChipClosedEventHandler">
 </Chip>
 ```
@@ -1143,7 +1144,7 @@ private void CloseModal()
 ## Pill
 
 ```razor
-<Pill Variant="PillVariant.custom" PillColor="white" Background="purple">
+<Pill Variant="PillVariant.custom" PillColor="white" Background="purple" TooltipText="Tooltip Text">
     Label
 </Pill>
 ```

--- a/SiemensIXBlazor.Tests/ChipTests.cs
+++ b/SiemensIXBlazor.Tests/ChipTests.cs
@@ -25,12 +25,13 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.Closable, true);
                 parameters.Add(p => p.ChipColor, "testColor");
                 parameters.Add(p => p.Icon, "testIcon");
+                parameters.Add(p => p.TooltipText, "tooltipText");
                 parameters.Add(p => p.Outline, true);
                 parameters.Add(p => p.Variant, Enums.Chip.ChipVariant.neutral);
             });
 
             // Assert
-            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" active=\"\" background=\"testBackground\" chip-color=\"testColor\" icon=\"testIcon\" variant=\"neutral\"></ix-chip>");
+            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" active=\"\" background=\"testBackground\" chip-color=\"testColor\" icon=\"testIcon\" variant=\"neutral\" tooltip-text='tooltipText'></ix-chip>");
         }
 
         [Fact]

--- a/SiemensIXBlazor.Tests/PillTest.cs
+++ b/SiemensIXBlazor.Tests/PillTest.cs
@@ -26,6 +26,7 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.Background, "red");
                 parameters.Add(p => p.PillColor, "white");
                 parameters.Add(p => p.Icon, "testIcon");
+                parameters.Add(p => p.TooltipText, "tooltipText");
                 parameters.Add(p => p.Outline, true);
                 parameters.Add(p => p.Variant, PillVariant.primary);
                 parameters.Add(p => p.ChildContent, builder =>
@@ -37,7 +38,7 @@ namespace SiemensIXBlazor.Tests
             });
 
             // Assert
-            cut.MarkupMatches("<ix-pill align-left=\"\" background=\"red\" pill-color=\"white\" icon=\"testIcon\" outline=\"\" variant=\"primary\"><div>Test child content</div></ix-pill>");
+            cut.MarkupMatches("<ix-pill align-left=\"\" background=\"red\" pill-color=\"white\" icon=\"testIcon\" outline=\"\" variant=\"primary\" tooltip-text='tooltipText'><div>Test child content</div></ix-pill>");
         }
 
         [Fact]

--- a/SiemensIXBlazor/Components/Chip/Chip.razor
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor
@@ -17,4 +17,4 @@
 
 <ix-chip @attributes="UserAttributes" id="@Id" closable="@Closable" outline="@Outline" active="@Active"
     background="@Background" chip-color="@ChipColor" icon="@Icon" variant="@(EnumParser<ChipVariant>.EnumToString(Variant))"
-    style="@Style" class="@Class">@ChildContent</ix-chip>
+    style="@Style" class="@Class" tooltip-text="@TooltipText">@ChildContent</ix-chip>

--- a/SiemensIXBlazor/Components/Chip/Chip.razor.cs
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor.cs
@@ -31,6 +31,8 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? Icon { get; set; }
         [Parameter]
+        public string? TooltipText { get; set; }
+        [Parameter]
         public bool Outline { get; set; } = false;
         [Parameter]
         public ChipVariant Variant { get; set; } = ChipVariant.primary;

--- a/SiemensIXBlazor/Components/Pill/Pill.razor
+++ b/SiemensIXBlazor/Components/Pill/Pill.razor
@@ -14,6 +14,6 @@
 @inherits IXBaseComponent
 
 <ix-pill @attributes="UserAttributes" variant="@(EnumParser<PillVariant>.EnumToString(Variant))" pill-color="@PillColor"
-    background="@Background" align-left="@AlignLeft" icon="@Icon" outline="@Outline" style="@Style" class="@Class">
+    background="@Background" align-left="@AlignLeft" icon="@Icon" outline="@Outline" style="@Style" class="@Class" tooltip-text="@TooltipText">
     @ChildContent
 </ix-pill>

--- a/SiemensIXBlazor/Components/Pill/Pill.razor.cs
+++ b/SiemensIXBlazor/Components/Pill/Pill.razor.cs
@@ -12,22 +12,24 @@ using SiemensIXBlazor.Enums.Pill;
 
 namespace SiemensIXBlazor.Components
 {
-	public partial class Pill
-	{
+    public partial class Pill
+    {
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
-		public bool AlignLeft { get; set; } = false;
-		[Parameter]
-		public string? Background { get; set; }
-		[Parameter]
-		public string? PillColor { get; set; }
-		[Parameter]
-		public string? Icon { get; set; }
-		[Parameter]
-		public bool Outline { get; set; } = false;
-		[Parameter]
-		public PillVariant Variant { get; set; } = PillVariant.primary;
-	}
+        public bool AlignLeft { get; set; } = false;
+        [Parameter]
+        public string? Background { get; set; }
+        [Parameter]
+        public string? PillColor { get; set; }
+        [Parameter]
+        public string? Icon { get; set; }
+        [Parameter]
+        public string? TooltipText { get; set; }
+        [Parameter]
+        public bool Outline { get; set; } = false;
+        [Parameter]
+        public PillVariant Variant { get; set; } = PillVariant.primary;
+    }
 }
 


### PR DESCRIPTION
## 💡 What is the current behavior?

- Currently, the `Chip` and `Pill` components do not support displaying tooltip text.

## 🆕 What is the new behavior?

- Added a `TooltipText` parameter to `Chip` and `Pill` components to support optional hover tooltips.
- Implemented unit tests to verify correct rendering and behavior of the tooltip text.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)