### PR TITLE
feat(MessageBar): add new types and deprecate danger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,7 @@ private void DrawerButtonClicked()
 ## Message bar
 
 ```razor
-<MessageBar ClosedChangeEvent="MessageboxClosed" Id="messagebar1" Type="MessageBarType.Danger">
+<MessageBar ClosedChangeEvent="MessageboxClosed" Id="messagebar1" Type="MessageBarType.Info">
     <div class="d-flex align-items-center justify-content-between">
         Message text <ix-button>Action</ix-button>
     </div>

--- a/SiemensIXBlazor/Enums/MessageBar/MessageBarType.cs
+++ b/SiemensIXBlazor/Enums/MessageBar/MessageBarType.cs
@@ -11,8 +11,14 @@ namespace SiemensIXBlazor.Enums.MessageBar
 {
     public enum MessageBarType
     {
+        Alarm,
+        [Obsolete("Type `danger` will be removed in future versions. Use `alarm` instead.")]
         Danger,
+        Critical,
+        Warning,
+        Success,
         Info,
-        Warning
+        Neutral,
+        Primary
     }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

- The `MessageBar` component still includes the deprecated `danger` message type without a deprecation notice.
- Documentation example currently uses the deprecated `danger` type.

## 🆕 What is the new behavior?

- Added new message types to `MessageBar`.
- Marked the `danger` type as deprecated.
- Updated documentation example to use `info` instead of `danger`.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)
