### PR TITLE
tests: add TimePicker and Toast tests

### DIFF
--- a/SiemensIXBlazor.Tests/TimePickerTests.cs
+++ b/SiemensIXBlazor.Tests/TimePickerTests.cs
@@ -1,0 +1,137 @@
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Moq;
+using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.DatePicker;
+
+namespace SiemensIXBlazor.Tests
+{
+    public class TimePickerTests : TestContextBase
+    {
+        [Fact]
+        public void ComponentRendersWithDefaultParameters()
+        {
+            // Arrange & Act
+            var cut = RenderComponent<TimePicker>(parameters => parameters
+                .Add(p => p.Id, "tp-default")
+            );
+            var picker = cut.Find("ix-time-picker");
+
+            // Assert required attributes
+            Assert.Equal("tp-default", picker.GetAttribute("id"));
+            Assert.Equal("rounded", picker.GetAttribute("corners"));
+            Assert.Equal("yyyy/MM/dd", picker.GetAttribute("format"));
+            Assert.Null(picker.GetAttribute("show-hour"));
+            Assert.Null(picker.GetAttribute("show-minutes"));
+            Assert.Null(picker.GetAttribute("show-seconds"));
+            Assert.Equal("Done", picker.GetAttribute("text-select-time"));
+            // Default Time is dynamic; just assert it's non-empty
+            Assert.False(string.IsNullOrWhiteSpace(picker.GetAttribute("time")));
+        }
+
+        [Theory]
+        [InlineData(DatePickerCorners.Left, "left")]
+        [InlineData(DatePickerCorners.Right, "right")]
+        [InlineData(DatePickerCorners.Rounded, "rounded")]
+        public void CornersRenderCorrectly(DatePickerCorners corners, string expected)
+        {
+            // Arrange & Act
+            var cut = RenderComponent<TimePicker>(parameters => parameters
+                .Add(p => p.Id, "tp-corners")
+                .Add(p => p.Corners, corners)
+            );
+            var picker = cut.Find("ix-time-picker");
+
+            // Assert corners attribute matches enum string
+            Assert.Equal(expected, picker.GetAttribute("corners"));
+        }
+
+        [Fact]
+        public void ComponentRendersWithAllParametersSetCorrectly()
+        {
+            // Because Format is a static property, set it directly
+            TimePicker.Format = "MM-dd";
+
+            // Arrange & Act
+            var cut = RenderComponent<TimePicker>(parameters => parameters
+                .AddUnmatched("data-test", "my-value")
+                .Add(p => p.Id, "tp1")
+                .Add(p => p.Corners, DatePickerCorners.Left)
+                .Add(p => p.ShowHour, true)
+                .Add(p => p.ShowMinutes, true)
+                .Add(p => p.ShowSeconds, true)
+                .Add(p => p.TextSelectTime, "SelectTime")
+                .Add(p => p.Time, "2025-04-24T15:30:00")
+                .Add(p => p.Class, "my-class")
+                .Add(p => p.Style, "color:red;")
+            );
+
+            // Assert full markup
+            cut.MarkupMatches(
+                @"<ix-time-picker data-test=""my-value"" id=""tp1""
+                    corners=""left""
+                    format=""MM-dd""
+                    show-hour
+                    show-minutes
+                    show-seconds
+                    text-select-time=""SelectTime""
+                    time=""2025-04-24T15:30:00""
+                    style=""display: block; width: 20rem; color:red;""
+                    class=""my-class"">
+                </ix-time-picker>"
+            );
+
+            // Reset static Format to default for other tests
+            TimePicker.Format = "yyyy/MM/dd";
+        }
+
+        [Fact]
+        public void OnAfterRender_InvokesJsRuntimeImportForModule()
+        {
+            // Arrange
+            var jsRuntimeMock = Mock.Get(Services.GetRequiredService<IJSRuntime>());
+
+            // Act: first render triggers OnAfterRenderAsync(true)
+            RenderComponent<TimePicker>(parameters => parameters.Add(p => p.Id, "tp-js"));
+
+            // Assert: import called once to load the JS module
+            jsRuntimeMock.Verify(
+                js => js.InvokeAsync<IJSObjectReference>(
+                    "import", It.IsAny<object[]>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task DoneAndTimeChanged_JsInvokable_InvokeEventCallbacks()
+        {
+            // Arrange
+            var cut = RenderComponent<TimePicker>(parameters => parameters
+                .Add(p => p.Id, "tp-callback")
+                .Add(p => p.DoneEvent, EventCallback.Factory.Create<string>(this, (string d) => DoneValue = d))
+                .Add(p => p.TimeChangeEvent, EventCallback.Factory.Create<string>(this, (string d) => TimeChangedValue = d))
+            );
+
+            // Act: invoke the two JSInvokable methods
+            await cut.InvokeAsync(() => cut.Instance.Done("2025/04/24"));
+            await cut.InvokeAsync(() => cut.Instance.TimeChanged("2025/04/25"));
+
+            // Assert that our handlers were called
+            Assert.Equal("2025/04/24", DoneValue);
+            Assert.Equal("2025/04/25", TimeChangedValue);
+        }
+
+        private string? DoneValue { get; set; }
+        private string? TimeChangedValue { get; set; }
+    }
+}

--- a/SiemensIXBlazor.Tests/ToastTests.cs
+++ b/SiemensIXBlazor.Tests/ToastTests.cs
@@ -1,0 +1,240 @@
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2025 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Moq;
+using Newtonsoft.Json;
+using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Objects;
+
+namespace SiemensIXBlazor.Tests
+{
+    public class ToastTests : TestContextBase
+    {
+        [Fact]
+        public void ComponentRendersWithoutCrashing()
+        {
+            // Arrange
+            var cut = RenderComponent<Toast>();
+
+            // Assert
+            cut.MarkupMatches("<ix-toast-container></ix-toast-container>");
+        }
+
+        [Fact]
+        public void UserAttributesAreAppliedCorrectly()
+        {
+            // Arrange
+            var attributes = new
+            {
+                role = "alert",
+                tabindex = "0",
+                id = "toast-container-1"
+            };
+
+            // Act
+            var cut = RenderComponent<Toast>(parameters => parameters
+                .AddUnmatched("role", attributes.role)
+                .AddUnmatched("tabindex", attributes.tabindex)
+                .AddUnmatched("id", attributes.id));
+
+            // Assert
+            cut.MarkupMatches($"<ix-toast-container role=\"{attributes.role}\" tabindex=\"{attributes.tabindex}\" id=\"{attributes.id}\"></ix-toast-container>");
+        }
+
+        [Fact]
+        public void StyleIsAppliedCorrectly()
+        {
+            // Arrange
+            var style = "position: fixed; top: 10px; right: 10px;";
+
+            // Act
+            var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Style, style));
+
+            // Assert
+            cut.MarkupMatches($"<ix-toast-container style=\"{style}\"></ix-toast-container>");
+        }
+
+        [Fact]
+        public void ClassIsAppliedCorrectly()
+        {
+            // Arrange
+            var className = "custom-toast-container";
+
+            // Act
+            var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Class, className));
+
+            // Assert
+            cut.MarkupMatches($"<ix-toast-container class=\"{className}\"></ix-toast-container>");
+        }
+
+        [Fact]
+        public async Task ShowToast_WithValidConfig_InvokesJSCorrectly()
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+            Services.AddSingleton(jsRuntimeMock.Object);
+
+            var toastConfig = new ToastConfig
+            {
+                Message = "Test message",
+                Title = "Test title",
+                Type = "success",
+                Icon = "info",
+                IconColor = "#00FF00",
+                AutoClose = true,
+                AutoCloseDelay = 3000
+            };
+
+            string expectedJson = JsonConvert.SerializeObject(toastConfig);
+
+            // Setup the expected JS call
+            jsRuntimeMock
+                .Setup(js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)))
+                .ReturnsAsync(new ValueTask<object>());
+
+            var cut = RenderComponent<Toast>();
+
+            // Act
+            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
+
+            // Assert
+            jsRuntimeMock.Verify(
+                js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ShowToast_WithNullConfig_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+            Services.AddSingleton(jsRuntimeMock.Object);
+            var cut = RenderComponent<Toast>();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await cut.InvokeAsync(() => cut.Instance.ShowToast(null)));
+        }
+
+        [Fact]
+        public async Task ShowToast_WithDefaultValues_UsesCorrectDefaults()
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+            Services.AddSingleton(jsRuntimeMock.Object);
+
+            var toastConfig = new ToastConfig
+            {
+                Message = "Test message"
+            };
+
+            jsRuntimeMock
+                .Setup(js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.Is<object[]>(args => VerifyToastConfigDefaults(args[0].ToString(), "Test message"))))
+                .ReturnsAsync(new ValueTask<object>());
+
+            var cut = RenderComponent<Toast>();
+
+            // Act
+            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
+
+            // Assert
+            jsRuntimeMock.Verify(
+                js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.IsAny<object[]>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ShowToast_WhenJSRuntimeThrowsException_PropagatesException()
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+            Services.AddSingleton(jsRuntimeMock.Object);
+
+            var toastConfig = new ToastConfig { Message = "Test message" };
+            var expectedException = new JSException("Test JS exception");
+
+            jsRuntimeMock
+                .Setup(js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.IsAny<object[]>()))
+                .ThrowsAsync(expectedException);
+
+            var cut = RenderComponent<Toast>();
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<JSException>(async () =>
+                await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig)));
+
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Theory]
+        [InlineData("info")]
+        [InlineData("success")]
+        [InlineData("warning")]
+        [InlineData("error")]
+        public async Task ShowToast_WithDifferentTypes_InvokesJSCorrectly(string toastType)
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+            Services.AddSingleton(jsRuntimeMock.Object);
+
+            var toastConfig = new ToastConfig
+            {
+                Message = "Test message",
+                Type = toastType
+            };
+
+            jsRuntimeMock
+                .Setup(js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).Type == toastType)))
+                .ReturnsAsync(new ValueTask<object>());
+
+            var cut = RenderComponent<Toast>();
+
+            // Act
+            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
+
+            // Assert
+            jsRuntimeMock.Verify(
+                js => js.InvokeAsync<object>(
+                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
+                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).Type == toastType)),
+                Times.Once);
+        }
+
+        #region Helper Methods
+
+        private bool VerifyToastConfigDefaults(string json, string expectedMessage)
+        {
+            var config = JsonConvert.DeserializeObject<ToastConfig>(json);
+            if (config == null)
+                return false;
+
+            return config.Message == expectedMessage &&
+                   config.Type == "info" &&
+                   config.AutoClose == true &&
+                   config.AutoCloseDelay == 5000;
+        }
+
+        #endregion
+    }
+}

--- a/SiemensIXBlazor/Components/Toast/Toast.razor.cs
+++ b/SiemensIXBlazor/Components/Toast/Toast.razor.cs
@@ -15,9 +15,21 @@ namespace SiemensIXBlazor.Components
 {
     public partial class Toast
     {
-        public async void ShowToast(ToastConfig config)
+        public async Task ShowToast(ToastConfig config)
         {
-            await JSRuntime.InvokeVoidAsync("siemensIXInterop.showMessage", JsonConvert.SerializeObject(config));
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config), "Toast configuration cannot be null");
+            }
+
+            try
+            {
+                await JSRuntime.InvokeAsync<object>("siemensIXInterop.showMessage", JsonConvert.SerializeObject(config));
+            }
+            catch (JSException jsException)
+            {
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

The `Toast` component's `ShowToast` method was not testable due to its direct use of `JSRuntime.InvokeVoidAsync` without exception handling or null checks. Additionally, there were no unit tests for the `TimePicker` and `Toast` components.


## 🆕 What is the new behavior?

- Refactored `Toast` component to improve testability:
  - Changed `ShowToast` method return type from `void` to `Task`
  - Added null check for the `config` parameter
  - Added exception handling for JS interop calls
- Added new unit tests for:
  - `TimePicker` component
  - `Toast` component

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)
