### PR TITLE
fix: remove InitialComponent interop

### DIFF
--- a/SiemensIXBlazor/Components/Tabs/Tabs.razor.cs
+++ b/SiemensIXBlazor/Components/Tabs/Tabs.razor.cs
@@ -41,7 +41,6 @@ namespace SiemensIXBlazor.Components
             {
                 _tabsInterop = new(JSRuntime);
 
-                await _tabsInterop.InitialComponent(Id);
                 await _tabsInterop.SubscribeEvents(this, Id, "selectedChange", "SelectedChange");
             }
         }

--- a/SiemensIXBlazor/Interops/TabsInterop.cs
+++ b/SiemensIXBlazor/Interops/TabsInterop.cs
@@ -24,7 +24,7 @@ namespace SiemensIXBlazor.Interops
         public async Task InitialComponent(string id)
         {
             var module = await moduleTask.Value;
-            await module.InvokeAsync<string>("initalTable", id);
+            await module.InvokeAsync<string>("initialTable", id);
         }
 
         public async Task SubscribeEvents(object classObject, string id, string eventName, string methodName)


### PR DESCRIPTION
## 💡 What is the current behavior?

The InitialComponent method in the interop layer was causing runtime errors on the JavaScript side when invoked. 

## 🆕 What is the new behavior?

- Removed usage of the InitialComponent interop method from the component to resolve JS runtime errors.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)
