### PR TITLE
Fix : Remove Wrong Component Type in MenuTest

### DIFF
--- a/SiemensIXBlazor.Tests/Menu/MenuTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuTest.cs
@@ -114,7 +114,7 @@ public class MenuTest : TestContextBase
     {
         // Arrange
         var eventTriggered = false;
-        var cut = RenderComponent<ApplicationHeader>(
+        var cut = RenderComponent<Components.Menu.Menu>(
             ("Id", "testId"),
             ("OpenAppSwitchEvent", EventCallback.Factory.Create(this, () => { eventTriggered = true; }))
         );


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

Wrong component type is used in Menu Test



## 🆕 What is the new behavior?

Replaced with Correct Component Type 

![image](https://github.com/user-attachments/assets/8ad796a3-774b-47d0-bb6c-8d8043d8c718)

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated
- [x ] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [ ] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
