### PR TITLE
fix: remove unsupported oval property from ToggleButton

### DIFF
--- a/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
@@ -9,7 +9,6 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using SiemensIXBlazor.Components.ToggleButton;
 using SiemensIXBlazor.Enums.Button;
 using Xunit;
 
@@ -29,12 +28,11 @@ namespace SiemensIXBlazor.Tests.ToggleButton
                 ("Loading", true),
                 ("Outline", true),
                 ("Pressed", true),
-                ("Variant", ButtonVariant.secondary),
-                ("Oval", true)
+                ("Variant", ButtonVariant.secondary)
             );
 
             // Assert
-            cut.MarkupMatches("<ix-toggle-button id=\"testId\" disabled ghost icon=\"test-icon\" loading outline pressed variant=\"secondary\" oval></ix-toggle-button>");
+            cut.MarkupMatches("<ix-toggle-button id=\"testId\" disabled ghost icon=\"test-icon\" loading outline pressed variant=\"secondary\"></ix-toggle-button>");
         }
 
         [Fact]

--- a/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor
+++ b/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor
@@ -16,4 +16,4 @@
 
 <ix-toggle-button @attributes="UserAttributes" class="@Class" style="@Style" id="@Id" disabled="@Disabled"
     ghost="@Ghost" icon="@Icon" loading="@Loading" outline="@Outline" pressed="@Pressed"
-    variant="@(EnumParser<ButtonVariant>.EnumToString(Variant))" oval="@Oval">@ChildContent</ix-toggle-button>
+    variant="@(EnumParser<ButtonVariant>.EnumToString(Variant))">@ChildContent</ix-toggle-button>

--- a/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor.cs
+++ b/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor.cs
@@ -35,8 +35,6 @@ namespace SiemensIXBlazor.Components.ToggleButton
         [Parameter]
         public ButtonVariant Variant { get; set; } = ButtonVariant.secondary;
         [Parameter]
-        public bool Oval { get; set; } = false;
-        [Parameter]
         public EventCallback<bool> PressedChangeEvent { get; set; }
 
         private BaseInterop _interop;


### PR DESCRIPTION
## 💡 What is the current behavior?

Oval property in `ToggleButton` is not part of the latest iX specification and should not be supported.

## 🆕 What is the new behavior?

- Removed `oval` property from `ToggleButton` 

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)
