### PR TITLE
chore(deps): Centralize and Update NuGet Package Versions via `Direct…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,18 @@
+<Project>
+
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.20" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageVersion Include="bunit" Version="1.40.0" />
+		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+	</ItemGroup>
+
+</Project>

--- a/SiemensIXBlazor.Tests/SiemensIXBlazor.Tests.csproj
+++ b/SiemensIXBlazor.Tests/SiemensIXBlazor.Tests.csproj
@@ -10,16 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.40.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="bunit" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SiemensIXBlazor/SiemensIXBlazor.csproj
+++ b/SiemensIXBlazor/SiemensIXBlazor.csproj
@@ -50,8 +50,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.20" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## 💡 What is the current behavior?

GitHub Issue Number: #168

## 🆕 What is the new behavior?

This change introduces and updates the `Directory.Packages.props` file to centrally manage NuGet package versions for the solution. The following packages are now managed centrally:

- Microsoft.AspNetCore.Components.Web (v8.0.20)
- Microsoft.NET.Test.Sdk (v17.14.1)
- bunit (v1.40.0)
- coverlet.collector (v6.0.4)
- Moq (v4.20.72)
- Newtonsoft.Json (v13.0.4)
- xunit (v2.9.3)
- xunit.runner.visualstudio (v3.1.4)

The property `<ManagePackageVersionsCentrally>` is set to true, enabling central management of package versions across all projects in the repository.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated
- [ ] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support

Maybe, not yet.