### PR TITLE
docs(readme): update Siemens.IX.Blazor OSS link to 0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1451,6 +1451,6 @@ If you want to use native `siemens-ix` html elements, you have to handle events 
 
 Copyright © 2025 [Siemens AG](https://www.siemens.com/).
 
-[Siemens Third-Party Software Disclosure Document](/docs/Siemens.IX.Blazor__0.5.3__READMEOSS.html)
+[Siemens Third-Party Software Disclosure Document](/docs/Siemens.IX.Blazor__0.5.4__READMEOSS.html)
 
 This project is MIT licensed.


### PR DESCRIPTION
## 💡 What is the current behavior?

The OSS README link in `README.md` points to the previous Siemens.IX.Blazor OSS package version.

## 🆕 What is the new behavior?

- Updated the Siemens.IX.Blazor OSS README link to version `0.5.4`

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)