### PR TITLE
Update NuGet push step to use login action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,5 +52,11 @@ jobs:
       - name: "Pack Project"
         run: dotnet pack ${{ env.PROJECT_PATH }} --no-restore --no-build --configuration Release -p:PackageVersion=${{ steps.version.outputs.version-without-v }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
 
+      - name: "NuGet Login"
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: Siemens
+
       - name: "Push Package"
-        run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }} --skip-duplicate --no-symbols
+        run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }} --skip-duplicate --no-symbols


### PR DESCRIPTION
## 💡 What is the current behavior?

The NuGet publishing workflow currently uses a static `NUGET_API_KEY` repository secret for publishing packages to nuget.org.


## 🆕 What is the new behavior?

- Updated the publish workflow to use NuGet trusted publishing with GitHub Actions OIDC.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [ ] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [ ] 🏗️ Successful compilation (`dotnet build`, changes pushed)