### PR TITLE
ci: temporarily revert NuGet publish to API key auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,11 +48,5 @@ jobs:
       - name: "Pack Project"
         run: dotnet pack ${{ env.PROJECT_PATH }} --no-restore --no-build --configuration Release -p:PackageVersion=${{ steps.version.outputs.version-without-v }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
 
-      - name: "NuGet Login"
-        id: login
-        uses: NuGet/login@v1
-        with:
-          user: Siemens
-
       - name: "Push Package"
-        run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }} --skip-duplicate --no-symbols
+        run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s ${{ env.NUGET_SOURCE_URL }} --skip-duplicate --no-symbols


### PR DESCRIPTION
## 💡 What is the current behavior?

The publish workflow uses the NuGet login action for package publishing.

## 🆕 What is the new behavior?

- Revert NuGet publishing to API key authentication
- Remove the NuGet login step from the workflow