### PR TITLE
fix(blazor): resolve icon URLs relative to the application base

### DIFF
--- a/SiemensIXBlazor/SiemensIXBlazor_NpmJS/src/index.js
+++ b/SiemensIXBlazor/SiemensIXBlazor_NpmJS/src/index.js
@@ -12,7 +12,7 @@ window.echarts = echarts;
 window.siemensIXInterop = {
     async initialize() {
         await ixIconsDefineCustomElements(window, {
-            resourcesUrl: "/_content/Siemens.IX.Blazor/"
+            resourcesUrl: "./_content/Siemens.IX.Blazor/"
         });
 
         await defineCustomElements();


### PR DESCRIPTION
## 💡 What is the current behavior?

IX icon resources use a root-relative URL. When the application is hosted under a sub-path such as `/my-app`, the `/my-app` prefix is dropped and SVG requests return 404.

GitHub Issue Number: #239

## 🆕 What is the new behavior?

- Icon URLs now resolve relative to the document base and preserve the application base path.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)