### PR TITLE
fix(key-value): align slot and label API

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,24 +992,26 @@ private void DrawerButtonClicked()
 ## Key Value List
 
 ```razor
+@using SiemensIXBlazor.Enums.KeyValue
+
 <KeyValueList>
   <KeyValue
     Label="Label"
-    LabelPosition="left"
+    LabelPosition="@KeyValueLabelPosition.left"
     Value="Value"
-  ></KeyValue>
+  />
 
   <KeyValue
     Label="Label"
-    LabelPosition="left"
+    LabelPosition="@KeyValueLabelPosition.left"
     Value="Value"
-  ></KeyValue>
+  />
 
   <KeyValue
     Label="Label"
-    LabelPosition="left"
+    LabelPosition="@KeyValueLabelPosition.left"
     Value="Value"
-  ></KeyValue>
+  />
 </KeyValueList>
 ```
 
@@ -1017,12 +1019,9 @@ private void DrawerButtonClicked()
 
 ```razor
 <KeyValue Label="Label">
-  <input
-    class="form-control"
-    placeholder="Enter text here"
-    type="text"
-    slot="custom-value"
-  />
+  <CustomValue>
+    <input class="form-control" placeholder="Enter text here" type="text" />
+  </CustomValue>
 </KeyValue>
 ```
 

--- a/SiemensIXBlazor.Tests/KeyValueTest.cs
+++ b/SiemensIXBlazor.Tests/KeyValueTest.cs
@@ -10,24 +10,58 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.KeyValue;
 
 namespace SiemensIXBlazor.Tests;
 
 public class KeyValueTest : TestContextBase
 {
     [Fact]
-    public void ComponentRendersWithParametersSetCorrectly()
+    public void ComponentRendersCustomValueThroughNamedSlot()
     {
         // Arrange
         var cut = RenderComponent<KeyValue>(parameters => parameters
-            .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
+            .Add(p => p.CustomValue, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Icon, "testIcon")
+            .Add(p => p.AriaLabelIcon, "Test icon")
             .Add(p => p.Label, "testLabel")
-            .Add(p => p.LabelPosition, "left")
+            .Add(p => p.LabelPosition, KeyValueLabelPosition.left));
+
+        // Assert
+        var element = cut.Find("ix-key-value");
+        Assert.Equal("testIcon", element.GetAttribute("icon"));
+        Assert.Equal("Test icon", element.GetAttribute("aria-label-icon"));
+        Assert.Equal("testLabel", element.GetAttribute("label"));
+        Assert.Equal("left", element.GetAttribute("label-position"));
+
+        var customValue = cut.Find("[slot=\"custom-value\"]");
+        Assert.Equal("Test content", customValue.TextContent);
+    }
+
+    [Fact]
+    public void ComponentUsesTextValueInsteadOfCustomValueSlotWhenValueIsSet()
+    {
+        // Arrange
+        var cut = RenderComponent<KeyValue>(parameters => parameters
+            .Add(p => p.CustomValue, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
+            .Add(p => p.Label, "testLabel")
             .Add(p => p.Value, "testValue"));
 
         // Assert
-        cut.MarkupMatches(
-            "<ix-key-value label=\"testLabel\" value=\"testValue\" icon=\"testIcon\" label-position=\"left\">Test content</ix-key-value>");
+        var element = cut.Find("ix-key-value");
+        Assert.Equal("testValue", element.GetAttribute("value"));
+        Assert.Empty(cut.FindAll("[slot=\"custom-value\"]"));
+    }
+
+    [Fact]
+    public void ComponentUsesOfficialDefaultLabelPosition()
+    {
+        // Arrange
+        var cut = RenderComponent<KeyValue>(parameters => parameters
+            .Add(p => p.Label, "testLabel"));
+
+        // Assert
+        Assert.Equal(KeyValueLabelPosition.top, cut.Instance.LabelPosition);
+        Assert.Equal("top", cut.Find("ix-key-value").GetAttribute("label-position"));
     }
 }

--- a/SiemensIXBlazor/Components/KeyValue/KeyValue.razor
+++ b/SiemensIXBlazor/Components/KeyValue/KeyValue.razor
@@ -9,6 +9,8 @@
 *@
 
 @namespace SiemensIXBlazor.Components
+@using SiemensIXBlazor.Enums.KeyValue
+@using SiemensIXBlazor.Helpers
 @inherits IXBaseComponent
 <ix-key-value @attributes="UserAttributes"
               class="@Class"
@@ -17,7 +19,11 @@
               value="@Value"
               icon="@Icon"
               aria-label-icon="@AriaLabelIcon"
-              label-position="@LabelPosition">
-    @ChildContent
+              label-position="@(EnumParser<KeyValueLabelPosition>.EnumToString(LabelPosition))">
+    @if (Value is null && CustomValue is not null)
+    {
+        <div slot="custom-value">
+            @CustomValue
+        </div>
+    }
 </ix-key-value>
-

--- a/SiemensIXBlazor/Components/KeyValue/KeyValue.razor.cs
+++ b/SiemensIXBlazor/Components/KeyValue/KeyValue.razor.cs
@@ -7,15 +7,18 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using System;
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.KeyValue;
 
 namespace SiemensIXBlazor.Components
 {
 	public partial class KeyValue
 	{
+        /// <summary>
+        /// Optional custom value content rendered through the official custom-value slot.
+        /// </summary>
         [Parameter]
-        public RenderFragment? ChildContent { get; set; }
+        public RenderFragment? CustomValue { get; set; }
         /// <summary>
         /// Optional key value icon
         /// </summary>
@@ -28,13 +31,13 @@ namespace SiemensIXBlazor.Components
         /// <summary>
         /// Key value label
         /// </summary>
-        [Parameter]
-		public string? Label { get; set; }
+        [Parameter, EditorRequired]
+		public string Label { get; set; } = string.Empty;
         /// <summary>
         /// Optional key value label position - 'top' or 'left'
         /// </summary>
         [Parameter]
-		public string LabelPosition { get; set; } = "top";
+		public KeyValueLabelPosition LabelPosition { get; set; } = KeyValueLabelPosition.top;
         /// <summary>
         /// Optional key value text value
         /// </summary>
@@ -42,4 +45,3 @@ namespace SiemensIXBlazor.Components
 		public string? Value { get; set; }
 	}
 }
-

--- a/SiemensIXBlazor/Enums/KeyValue/KeyValueLabelPosition.cs
+++ b/SiemensIXBlazor/Enums/KeyValue/KeyValueLabelPosition.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.KeyValue
+{
+    public enum KeyValueLabelPosition
+    {
+        top,
+        left
+    }
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

The KeyValue wrapper exposed child content as the default slot instead of the official `custom-value` slot. `LabelPosition` was also an unrestricted string, and the README used the outdated slot pattern.

GitHub Issue Number: #271 

## 🆕 What is the new behavior?

- `LabelPosition` uses the typed `KeyValueLabelPosition` enum with `top` and `left`.
- `CustomValue` maps to the official `custom-value` slot, while `Value` takes precedence.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)