### PR TITLE
feat(content-header): add header slot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,10 @@ chart1.InitialChart(object1);
             HeaderTitle="Content title"
             HeaderSubTitle="Subtitle"
             BackButtonClickedEvent="ContentHeaderBackButtonClicked">
-    Test
+    <HeaderContent>
+        <span>Draft</span>
+    </HeaderContent>
+    <Button>Save</Button>
 </ContentHeader>
 ```
 

--- a/SiemensIXBlazor.Tests/ContentHeaderTests.cs
+++ b/SiemensIXBlazor.Tests/ContentHeaderTests.cs
@@ -50,6 +50,34 @@ namespace SiemensIXBlazor.Tests
         }
 
         [Fact]
+        public void ContentHeaderRendersHeaderSlot()
+        {
+            // Arrange
+            var expectedHeaderContent = "Header content";
+
+            // Act
+            var cut = RenderComponent<ContentHeader>(parameters => parameters
+                .Add(p => p.HeaderContent, builder =>
+                {
+                    builder.AddContent(0, expectedHeaderContent);
+                }));
+
+            // Assert
+            Assert.Contains("slot=\"header\"", cut.Markup);
+            Assert.Contains(expectedHeaderContent, cut.Markup);
+        }
+
+        [Fact]
+        public void ContentHeaderDoesNotRenderHeaderSlotWhenNull()
+        {
+            // Arrange & Act
+            var cut = RenderComponent<ContentHeader>();
+
+            // Assert
+            Assert.DoesNotContain("slot=\"header\"", cut.Markup);
+        }
+
+        [Fact]
         public void BackButtonClickedEventTriggeredCorrectly()
         {
             // Arrange

--- a/SiemensIXBlazor/Components/ContentHeader/ContentHeader.razor
+++ b/SiemensIXBlazor/Components/ContentHeader/ContentHeader.razor
@@ -18,5 +18,11 @@
 <ix-content-header @attributes="UserAttributes" class="@Class" style="@Style" id="@Id" has-back-button="@HasBackButton"
     header-title="@HeaderTitle" header-subtitle="@HeaderSubTitle"
     variant="@(EnumParser<ContentHeaderVariant>.EnumToString(Variant))">
+    @if (HeaderContent != null)
+    {
+        <div slot="header">
+            @HeaderContent
+        </div>
+    }
     @ChildContent
 </ix-content-header>

--- a/SiemensIXBlazor/Components/ContentHeader/ContentHeader.razor.cs
+++ b/SiemensIXBlazor/Components/ContentHeader/ContentHeader.razor.cs
@@ -21,6 +21,8 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
+        public RenderFragment? HeaderContent { get; set; }
+        [Parameter]
         public bool HasBackButton { get; set; } = false;
         [Parameter]
         public string? HeaderSubTitle { get; set; }


### PR DESCRIPTION
## 💡 What is the current behavior?

`ContentHeader` does not currently expose the official `header` slot for content next to the title.

GitHub Issue Number: #270 

## 🆕 What is the new behavior?

- Added optional `HeaderContent` support mapped to the official `header` slot.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)