### PR TITLE
feat(progress-indicator): add helper text slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,16 @@ private void OnModalDismissed()
                    HelperText="Please wait while we process your request"
                    Size="@ProgressIndicatorSize.lg"
                    Status="@ProgressIndicatorStatus.info" />
+
+<ProgressIndicator Value="75"
+                   Label="Processing data..."
+                   Size="@ProgressIndicatorSize.lg"
+                   Status="@ProgressIndicatorStatus.info">
+    <HelperTextContent>
+        <span>Custom helper text</span>
+    </HelperTextContent>
+    <span>75%</span>
+</ProgressIndicator>
 ```
 
 ## Radio button

--- a/SiemensIXBlazor.Tests/ProgressIndicatorTests.cs
+++ b/SiemensIXBlazor.Tests/ProgressIndicatorTests.cs
@@ -8,6 +8,7 @@
 //  -----------------------------------------------------------------------
 
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
 using SiemensIXBlazor.Enums.ProgressIndicator;
 
@@ -78,6 +79,23 @@ namespace SiemensIXBlazor.Tests
 
             // Assert
             cut.MarkupMatches(@"<ix-progress-indicator max=""100"" min=""0"" size=""md"" status=""error"" text-alignment=""center"" type=""linear"" value=""25""></ix-progress-indicator>");
+        }
+
+        [Fact]
+        public void ProgressIndicatorRendersHelperTextSlotAlongsideDefaultContent()
+        {
+            var helperText = (RenderFragment)(builder => builder.AddContent(0, "Custom helper text"));
+            var content = (RenderFragment)(builder => builder.AddContent(0, "50%"));
+
+            var cut = RenderComponent<ProgressIndicator>(parameters => parameters
+                .Add(p => p.HelperTextContent, helperText)
+                .Add(p => p.ChildContent, content));
+
+            var indicatorMarkup = cut.Find("ix-progress-indicator").InnerHtml;
+
+            Assert.Contains("slot=\"helper-text\"", indicatorMarkup);
+            Assert.Contains("Custom helper text", indicatorMarkup);
+            Assert.Contains("50%", indicatorMarkup);
         }
     }
 }

--- a/SiemensIXBlazor/Components/ProgressIndicator/ProgressIndicator.razor
+++ b/SiemensIXBlazor/Components/ProgressIndicator/ProgressIndicator.razor
@@ -21,4 +21,10 @@
     text-alignment="@(EnumParser<ProgressIndicatorTextAlignment>.EnumToString(TextAlignment))"
     type="@(EnumParser<ProgressIndicatorType>.EnumToString(Type))" value="@Value">
   @ChildContent
+  @if (HelperTextContent != null)
+  {
+      <div slot="helper-text">
+          @HelperTextContent
+      </div>
+  }
 </ix-progress-indicator>

--- a/SiemensIXBlazor/Components/ProgressIndicator/ProgressIndicator.razor.cs
+++ b/SiemensIXBlazor/Components/ProgressIndicator/ProgressIndicator.razor.cs
@@ -29,6 +29,12 @@ namespace SiemensIXBlazor.Components
         public string? HelperText { get; set; }
 
         /// <summary>
+        /// Custom helper text content for the progress indicator.
+        /// </summary>
+        [Parameter]
+        public RenderFragment? HelperTextContent { get; set; }
+
+        /// <summary>
         /// The label for the progress indicator.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
## 💡 What is the current behavior?

`ProgressIndicator` does not expose the official `helper-text` slot for custom helper content.

GitHub Issue Number: #272 

## 🆕 What is the new behavior?

- Added `HelperTextContent` support mapped to the official `helper-text` slot.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)