### PR TITLE
feat(blind): add custom header slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,10 +487,17 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
 
 ```razor
 <Blind
-    Label="Test Blind"
     Id="blind1"
     CollapsedChangedEvent="(value) => BlindEventHandler(value)">
-Test content
+    <CustomHeader>
+        <span>Custom header</span>
+    </CustomHeader>
+    <HeaderActions>
+        <Button Variant="@ButtonVariant.secondary">Action</Button>
+    </HeaderActions>
+    <ChildContent>
+        <p>Test content</p>
+    </ChildContent>
 </Blind>
 ```
 

--- a/SiemensIXBlazor.Tests/BlindTests.cs
+++ b/SiemensIXBlazor.Tests/BlindTests.cs
@@ -23,7 +23,7 @@ namespace SiemensIXBlazor.Tests
             var cut = RenderComponent<Blind>();
 
             // Assert
-            cut.MarkupMatches("<ix-blind id='' variant='insight'></ix-blind>");
+            cut.MarkupMatches("<ix-blind id='' variant='filled'></ix-blind>");
         }
 
         [Fact]
@@ -60,10 +60,37 @@ namespace SiemensIXBlazor.Tests
         public void VariantPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Variant, BlindVariant.insight));
+            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Variant, BlindVariant.filled));
 
             // Assert
-            Assert.Equal(BlindVariant.insight, cut.Instance.Variant);
+            Assert.Equal(BlindVariant.filled, cut.Instance.Variant);
+        }
+
+        [Fact]
+        public void BlindRendersCustomHeaderAndHeaderActionsSlots()
+        {
+            var cut = RenderComponent<Blind>(parameters => parameters
+                .Add(p => p.CustomHeader, builder => builder.AddContent(0, "Custom header"))
+                .Add(p => p.HeaderActions, builder => builder.AddContent(0, "Actions"))
+                .Add(p => p.ChildContent, builder => builder.AddContent(0, "Blind content")));
+
+            Assert.Contains("slot=\"custom-header\"", cut.Markup);
+            Assert.Contains("Custom header", cut.Markup);
+            Assert.Contains("slot=\"header-actions\"", cut.Markup);
+            Assert.Contains("Actions", cut.Markup);
+            Assert.Contains("Blind content", cut.Markup);
+        }
+
+        [Fact]
+        public async Task CollapsedChangedEventPassesTypedValue()
+        {
+            var collapsed = false;
+            var cut = RenderComponent<Blind>(parameters => parameters
+                .Add(p => p.CollapsedChangedEvent, EventCallback.Factory.Create<bool>(this, value => collapsed = value)));
+
+            await cut.Instance.CollapsedChanged(true);
+
+            Assert.True(collapsed);
         }
 
         [Fact]

--- a/SiemensIXBlazor/Components/Blind/Blind.razor
+++ b/SiemensIXBlazor/Components/Blind/Blind.razor
@@ -18,5 +18,17 @@
 
 <ix-blind @attributes="UserAttributes" class="@Class" style="@Style" id="@Id" label="@Label" sublabel="@SubLabel"
   collapsed="@Collapsed" icon="@Icon" variant="@(EnumParser<BlindVariant>.EnumToString(Variant))">
+  @if (CustomHeader != null)
+  {
+      <div slot="custom-header">
+          @CustomHeader
+      </div>
+  }
+  @if (HeaderActions != null)
+  {
+      <div slot="header-actions">
+          @HeaderActions
+      </div>
+  }
   @ChildContent
 </ix-blind>

--- a/SiemensIXBlazor/Components/Blind/Blind.razor.cs
+++ b/SiemensIXBlazor/Components/Blind/Blind.razor.cs
@@ -21,6 +21,10 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? SubLabel { get; set; }
         [Parameter]
+        public RenderFragment? CustomHeader { get; set; }
+        [Parameter]
+        public RenderFragment? HeaderActions { get; set; }
+        [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter, EditorRequired]
         public string Id { get; set; } = string.Empty;
@@ -29,7 +33,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? Icon { get; set; }
         [Parameter]
-        public BlindVariant Variant { get; set; } = BlindVariant.insight;
+        public BlindVariant Variant { get; set; } = BlindVariant.filled;
         [Parameter]
         public EventCallback<bool> CollapsedChangedEvent { get; set; }
 

--- a/SiemensIXBlazor/Enums/Blind/BlindVariant.cs
+++ b/SiemensIXBlazor/Enums/Blind/BlindVariant.cs
@@ -13,10 +13,9 @@ namespace SiemensIXBlazor.Enums.Blind
     {
         alarm,
         critical,
+        filled,
         info,
-        insight,
         neutral,
-        notification,
         outline,
         primary,
         success,


### PR DESCRIPTION
## 💡 What is the current behavior?

The Blind wrapper did not expose the official custom header slots, and its default/public variants were not aligned with the current IX API.

GitHub Issue Number: #269 

## 🆕 What is the new behavior?

- CustomHeader and HeaderActions are mapped to the official Blind slots.
- Blind now uses the official filled default and supported variant values.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)