### PR TITLE
feat(avatar): add tooltip text support

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,9 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
 
 ```razor
 <Avatar
-    Image="https://ui-avatars.com/api/?name=John+Doe">
+    Image="https://ui-avatars.com/api/?name=John+Doe"
+    TooltipText="John Doe"
+    AriaLabelTooltip="John Doe">
 </Avatar>
 ```
 

--- a/SiemensIXBlazor.Tests/AvatarTests.cs
+++ b/SiemensIXBlazor.Tests/AvatarTests.cs
@@ -20,6 +20,7 @@ namespace SiemensIXBlazor.Tests
             // Arrange
             var cut = RenderComponent<Avatar>(parameters => {
                 parameters.Add(p => p.Image, "testImage");
+                parameters.Add(p => p.TooltipText, "testTooltipText");
                 parameters.Add(p => p.Initials, "testInitials");
                 parameters.Add(p => p.AriaLabel, "testAriaLabel");
                 parameters.Add(p => p.AriaLabelTooltip, "testAriaLabelTooltip");
@@ -27,7 +28,20 @@ namespace SiemensIXBlazor.Tests
             });
         
             // Assert
-            cut.MarkupMatches("<ix-avatar image='testImage' initials='testInitials' aria-label='testAriaLabel' aria-label-tooltip='testAriaLabelTooltip'></ix-avatar>");
+            cut.MarkupMatches("<ix-avatar image='testImage' tooltip-text='testTooltipText' initials='testInitials' aria-label='testAriaLabel' aria-label-tooltip='testAriaLabelTooltip'></ix-avatar>");
+        }
+
+        [Fact]
+        public void TooltipTextIsRenderedWithoutChangingOtherAvatarOptions()
+        {
+            var cut = RenderComponent<Avatar>(parameters => parameters
+                .Add(p => p.Initials, "JD")
+                .Add(p => p.TooltipText, "John Doe"));
+
+            Assert.Equal("JD", cut.Instance.Initials);
+            Assert.Equal("John Doe", cut.Instance.TooltipText);
+            Assert.Contains("initials=\"JD\"", cut.Markup);
+            Assert.Contains("tooltip-text=\"John Doe\"", cut.Markup);
         }
     }
 }

--- a/SiemensIXBlazor/Components/Avatar/Avatar.razor
+++ b/SiemensIXBlazor/Components/Avatar/Avatar.razor
@@ -14,6 +14,7 @@
            class="@Class" 
            style="@Style" 
            image="@Image" 
+           tooltip-text="@TooltipText"
            aria-label="@AriaLabel"
            aria-label-tooltip="@AriaLabelTooltip" 
            initials="@Initials"

--- a/SiemensIXBlazor/Components/Avatar/Avatar.razor.cs
+++ b/SiemensIXBlazor/Components/Avatar/Avatar.razor.cs
@@ -16,6 +16,8 @@ namespace SiemensIXBlazor.Components.Avatar
         [Parameter]
         public string? Image { get; set; }
         [Parameter]
+        public string? TooltipText { get; set; }
+        [Parameter]
         public string? Initials { get; set; }
         [Parameter]
         public string? AriaLabel { get; set; }


### PR DESCRIPTION
## 💡 What is the current behavior?

Avatar did not expose the official `tooltipText` property, so wrapper users could not configure Avatar hover text.

GitHub Issue Number: #260 

## 🆕 What is the new behavior?

- Added the public `TooltipText` parameter to the Avatar wrapper.
- Mapped it to the official `tooltip-text` attribute.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)