### PR TITLE
fix(kpi): align value and warning icon bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,13 @@ private void DrawerButtonClicked()
 ## KPI
 
 ```razor
-<KPI Label="Motor speed" Value="Nominal"></KPI>
+<KPI Label="Motor speed"
+     Value="@("Nominal")"
+     Unit="rpm"
+     State="@KpiState.Warning"
+     AriaLabelWarningIcon="Motor speed warning" />
+
+<KPI Label="Temperature" Value="@(42)" Unit="°C" />
 ```
 
 ## Layout Grid

--- a/SiemensIXBlazor.Tests/KPITest.cs
+++ b/SiemensIXBlazor.Tests/KPITest.cs
@@ -24,10 +24,26 @@ public class KPITest : TestContextBase
             .Add(p => p.Orientation, KpiOrientation.Horizontal)
             .Add(p => p.State, KpiState.Neutral)
             .Add(p => p.Unit, "testUnit")
-            .Add(p => p.Value, "testValue"));
+            .Add(p => p.Value, "testValue")
+            .Add(p => p.AriaLabelWarningIcon, "Warning status"));
 
         // Assert
-        cut.MarkupMatches("<ix-kpi label=\"testLabel\" value=\"testValue\" orientation=\"horizontal\" state=\"neutral\" onreadystatechange=\"Neutral\" unit=\"testUnit\" aria-label-warning-icon=\"AriaLabelWarningIcon\"></ix-kpi>");
+        cut.MarkupMatches("<ix-kpi label=\"testLabel\" value=\"testValue\" aria-label-warning-icon=\"Warning status\" orientation=\"horizontal\" state=\"neutral\" unit=\"testUnit\"></ix-kpi>");
 
+    }
+
+    [Fact]
+    public void ComponentRendersNumericValueWithoutUnsupportedAttributes()
+    {
+        var cut = RenderComponent<KPI>(parameters => parameters
+            .Add(p => p.Label, "Temperature")
+            .Add(p => p.Value, 42)
+            .Add(p => p.State, KpiState.Warning)
+            .Add(p => p.AriaLabelWarningIcon, "Warning status"));
+
+        Assert.Equal(42, cut.Instance.Value);
+        Assert.Contains("value=\"42\"", cut.Markup);
+        Assert.Contains("aria-label-warning-icon=\"Warning status\"", cut.Markup);
+        Assert.DoesNotContain("onreadystatechange", cut.Markup);
     }
 }

--- a/SiemensIXBlazor/Components/KPI/KPI.razor
+++ b/SiemensIXBlazor/Components/KPI/KPI.razor
@@ -14,7 +14,7 @@
 @inherits IXBaseComponent
 
 <ix-kpi @attributes="UserAttributes" label="@Label" value="@Value"
-    aria-label-alarm-icon="@AriaLabelAlarmIcon" aria-label-warning-icon="AriaLabelWarningIcon"
+    aria-label-alarm-icon="@AriaLabelAlarmIcon" aria-label-warning-icon="@AriaLabelWarningIcon"
     orientation="@(EnumParser<KpiOrientation>.EnumToString(Orientation))"
-    state="@(EnumParser<KpiState>.EnumToString(State))" onreadystatechange="@State" unit="@Unit" style="@Style"
+    state="@(EnumParser<KpiState>.EnumToString(State))" unit="@Unit" style="@Style"
     class="@Class"></ix-kpi>

--- a/SiemensIXBlazor/Components/KPI/KPI.razor.cs
+++ b/SiemensIXBlazor/Components/KPI/KPI.razor.cs
@@ -27,6 +27,6 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? Unit { get; set; }
         [Parameter]
-        public string? Value { get; set; }
+        public object? Value { get; set; }
     }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

The KPI wrapper accepted only string values, incorrectly rendered the warning icon ARIA label, and included an unsupported `onreadystatechange` attribute.

GitHub Issue Number: #259 

## 🆕 What is the new behavior?

- KPI values now support both strings and numbers through the `object?` parameter.
- The warning icon ARIA label is mapped correctly.
- The unsupported `onreadystatechange` attribute has been removed.
- Tests and README examples were updated.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)