### PR TITLE
feat(chip): complete accessibility and tooltip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,11 +733,17 @@ chart1.InitialChart(object1);
 
 ```razor
 <Chip Icon="print"
-      Label="Chip with icon"
       Id="chip1"
-      Closable="true"
-      TooltipText="Tooltip Text"
+      AriaLabelIcon="Print"
+      Closable
+      TooltipText="@("Tooltip Text")"
       ClosedEvent="@ChipClosedEventHandler">
+    Chip with icon
+</Chip>
+
+<Chip Id="chip-text-tooltip"
+      TooltipText="@true">
+    Uses chip text as tooltip
 </Chip>
 ```
 

--- a/SiemensIXBlazor.Tests/ChipTests.cs
+++ b/SiemensIXBlazor.Tests/ChipTests.cs
@@ -33,7 +33,7 @@ namespace SiemensIXBlazor.Tests
             });
 
             // Assert
-            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" inactive=\"\" background=\"testBackground\" center-content chip-color=\"testColor\" icon=\"testIcon\" variant=\"neutral\" tooltip-text='tooltipText'></ix-chip>");
+            cut.MarkupMatches("<ix-chip id=\"testId\" closable=\"\" outline=\"\" inactive=\"\" background=\"testBackground\" aria-label-close-button=\"Close chip\" center-content chip-color=\"testColor\" icon=\"testIcon\" variant=\"neutral\" tooltip-text='tooltipText'></ix-chip>");
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace SiemensIXBlazor.Tests
             });
 
             // Assert
-            cut.MarkupMatches("<ix-chip id=\"centeredChip\" center-content variant=\"primary\"></ix-chip>");
+            cut.MarkupMatches("<ix-chip id=\"centeredChip\" aria-label-close-button=\"Close chip\" center-content variant=\"primary\"></ix-chip>");
         }
 
         [Fact]
@@ -78,7 +78,34 @@ namespace SiemensIXBlazor.Tests
             });
 
             // Assert
-            cut.MarkupMatches("<ix-chip id=\"notCenteredChip\" variant=\"primary\"></ix-chip>");
+            cut.MarkupMatches("<ix-chip id=\"notCenteredChip\" aria-label-close-button=\"Close chip\" variant=\"primary\"></ix-chip>");
+        }
+
+        [Fact]
+        public void ChipMapsIconAccessibilityAndBooleanTooltip()
+        {
+            var cut = RenderComponent<Chip>(parameters => parameters
+                .Add(p => p.Id, "accessibleChip")
+                .Add(p => p.Icon, "info")
+                .Add(p => p.AriaLabelIcon, "Information")
+                .Add(p => p.TooltipText, true)
+                .Add(p => p.ChildContent, builder => builder.AddContent(0, "Chip label")));
+
+            Assert.Equal("Information", cut.Instance.AriaLabelIcon);
+            Assert.Equal(true, cut.Instance.TooltipText);
+            Assert.Contains("aria-label-icon=\"Information\"", cut.Markup);
+            Assert.Contains("tooltip-text=\"\"", cut.Markup);
+            Assert.DoesNotContain("tooltip-text=\"True\"", cut.Markup);
+        }
+
+        [Fact]
+        public void ChipFalseTooltipDoesNotRenderTooltipAttribute()
+        {
+            var cut = RenderComponent<Chip>(parameters => parameters
+                .Add(p => p.Id, "noTooltipChip")
+                .Add(p => p.TooltipText, false));
+
+            Assert.DoesNotContain("tooltip-text", cut.Markup);
         }
     }
 }

--- a/SiemensIXBlazor/Components/Chip/Chip.razor
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor
@@ -25,9 +25,10 @@
          center-content="@CenterContent"
          chip-color="@ChipColor" 
          icon="@Icon" 
+         aria-label-icon="@AriaLabelIcon"
          variant="@(EnumParser<ChipVariant>.EnumToString(Variant))"
          style="@Style" 
          class="@Class" 
-         tooltip-text="@TooltipText">
+         tooltip-text="@TooltipTextAttribute">
      @ChildContent
 </ix-chip>

--- a/SiemensIXBlazor/Components/Chip/Chip.razor.cs
+++ b/SiemensIXBlazor/Components/Chip/Chip.razor.cs
@@ -21,7 +21,9 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
-        public string? AriaLabelCloseButton { get; set; }
+        public string? AriaLabelCloseButton { get; set; } = "Close chip";
+        [Parameter]
+        public string? AriaLabelIcon { get; set; }
         [Parameter]
         public bool Inactive { get; set; } = false;
         [Parameter]
@@ -37,13 +39,20 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? Icon { get; set; }
         [Parameter]
-        public string? TooltipText { get; set; }
+        public object? TooltipText { get; set; }
         [Parameter]
         public bool Outline { get; set; } = false;
         [Parameter]
         public ChipVariant Variant { get; set; } = ChipVariant.primary;
         [Parameter]
         public EventCallback ClosedEvent { get; set; }
+
+        private string? TooltipTextAttribute => TooltipText switch
+        {
+            bool value => value ? string.Empty : null,
+            null => null,
+            _ => TooltipText.ToString()
+        };
 
         private BaseInterop _interop;
 


### PR DESCRIPTION
## 💡 What is the current behavior?

The Chip wrapper does not expose the official `aria-label-icon` attribute. Its `TooltipText` parameter only supports strings, and the default close-button ARIA label is missing.

GitHub Issue Number: #262 

## 🆕 What is the new behavior?

- `AriaLabelIcon` maps to `aria-label-icon`.
- `TooltipText` supports both custom strings and boolean tooltip behavior.
- `AriaLabelCloseButton` defaults to `Close chip`.
- Tests and README examples cover the updated API.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings (official default `Close chip` is preserved)
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)