### PR TITLE
feat(flip-tile): support numeric and automatic dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,10 @@ private void DrawerButtonClicked()
 ## Flip
 
 ```razor
-<FlipTile>
+<FlipTile Id="flip-tile-example"
+          Height="@("auto")"
+          Width="@("auto")"
+          AriaLabelEyeIconButton="Toggle view">
     <div slot="header">Flip header</div>
 
     <div slot="footer">

--- a/SiemensIXBlazor.Tests/Flip/FlipTileTest.cs
+++ b/SiemensIXBlazor.Tests/Flip/FlipTileTest.cs
@@ -148,6 +148,34 @@ public class FlipTileTest : TestContextBase
     }
 
     [Fact]
+    public void AutoHeightAndWidthRenderCorrectly()
+    {
+        var cut = RenderComponent<FlipTile>(parameters => parameters
+            .Add(p => p.Id, "ix-flip-auto")
+            .Add(p => p.Height, "auto")
+            .Add(p => p.Width, "auto"));
+
+        var element = cut.Find("ix-flip-tile");
+
+        Assert.Equal("auto", element.GetAttribute("height"));
+        Assert.Equal("auto", element.GetAttribute("width"));
+    }
+
+    [Fact]
+    public void NumberAndAutoDimensionsAreAccepted()
+    {
+        var cut = RenderComponent<FlipTile>(parameters => parameters
+            .Add(p => p.Id, "ix-flip-values")
+            .Add(p => p.Height, 20.5)
+            .Add(p => p.Width, "auto"));
+
+        var element = cut.Find("ix-flip-tile");
+
+        Assert.Equal("20.5", element.GetAttribute("height"));
+        Assert.Equal("auto", element.GetAttribute("width"));
+    }
+
+    [Fact]
     public void IndexPropertyRenders()
     {
         // Arrange & Act

--- a/SiemensIXBlazor/Components/Flip/FlipTile.razor.cs
+++ b/SiemensIXBlazor/Components/Flip/FlipTile.razor.cs
@@ -25,9 +25,9 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? AriaLabelEyeIconButton { get; set; }
         [Parameter]
-        public dynamic Height { get; set; } = 15.125;
+        public object Height { get; set; } = 15.125;
         [Parameter]
-        public dynamic Width { get; set; } = 16;
+        public object Width { get; set; } = 16;
 
         [Parameter]
         public int Index { get; set; } = 0;


### PR DESCRIPTION
## 💡 What is the current behavior?

FlipTile dimensions only supported numeric values, so the official `auto` dimension option was unavailable.

GitHub Issue Number: #264 

## 🆕 What is the new behavior?

- FlipTile accepts numeric values and `"auto"` for height and width.
- In Razor, `"auto"` is passed using an explicit expression because unquoted `auto` is parsed as a C# identifier.
- Tests cover numeric and `"auto"` dimension values, with the README documenting the `auto` usage.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)