### PR TITLE
feat(workflow): add custom icon slot and remove linear mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,7 +1418,12 @@ tree.TreeModel = treeNodes;
 
 ```razor
 <WorkflowSteps Id="wf-steps" StepSelectedEvent="(index) => WfSelectedEvent(index)">
-    <WorkflowStep Status="WorkflowStatus.Done">Step 1</WorkflowStep>
+    <WorkflowStep Status="WorkflowStatus.Done">
+        <CustomIcon>
+            <ix-icon name="star"></ix-icon>
+        </CustomIcon>
+        <ChildContent>Step 1</ChildContent>
+    </WorkflowStep>
     <WorkflowStep Status="WorkflowStatus.Success">Step 2</WorkflowStep>
     <WorkflowStep Status="WorkflowStatus.Open">Step 3</WorkflowStep>
     <WorkflowStep Status="WorkflowStatus.Warning">Step 4</WorkflowStep>

--- a/SiemensIXBlazor.Tests/Workflow/WorkflowStepTest.cs
+++ b/SiemensIXBlazor.Tests/Workflow/WorkflowStepTest.cs
@@ -33,5 +33,18 @@ namespace SiemensIXBlazor.Tests.Workflow
             // Assert
             cut.MarkupMatches("<ix-workflow-step clickable disabled position=\"first\" selected status=\"open\" vertical></ix-workflow-step>");
         }
+
+        [Fact]
+        public void CustomIconRendersInCustomIconSlot()
+        {
+            var cut = RenderComponent<WorkflowStep>(parameters => parameters
+                .Add(p => p.CustomIcon, (RenderFragment)(builder => builder.AddMarkupContent(0, "<ix-icon name=\"star\"></ix-icon>")))
+                .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddContent(0, "Step"))));
+
+            var iconSlot = cut.Find("[slot='custom-icon']");
+
+            Assert.Contains("star", iconSlot.InnerHtml);
+            Assert.Contains("Step", cut.Markup);
+        }
     }
 }

--- a/SiemensIXBlazor.Tests/Workflow/WorkflowStepsTest.cs
+++ b/SiemensIXBlazor.Tests/Workflow/WorkflowStepsTest.cs
@@ -23,13 +23,12 @@ namespace SiemensIXBlazor.Tests.Workflow
             var cut = RenderComponent<WorkflowSteps>(
                 ("Id", "testId"),
                 ("Clickable", true),
-                ("Linear", true),
                 ("SelectedIndex", 1),
                 ("Vertical", true)
             );
 
             // Assert
-            cut.MarkupMatches("<ix-workflow-steps id=\"testId\" clickable linear selected-index=\"1\" vertical></ix-workflow-steps>");
+            cut.MarkupMatches("<ix-workflow-steps id=\"testId\" clickable selected-index=\"1\" vertical></ix-workflow-steps>");
         }
 
         [Fact]

--- a/SiemensIXBlazor/Components/Workflow/WorkflowStep.razor
+++ b/SiemensIXBlazor/Components/Workflow/WorkflowStep.razor
@@ -16,5 +16,11 @@
 <ix-workflow-step @attributes="UserAttributes" style="@Style" class="@Class"
     status="@(EnumParser<WorkflowStatus>.EnumToString(Status))" clickable="@Clickable" disabled="@Disabled"
     position="@(EnumParser<WorkflowPosition>.EnumToString(Position))" selected="@Selected" vertical="@Vertical">
+    @if (CustomIcon != null)
+    {
+        <div slot="custom-icon">
+            @CustomIcon
+        </div>
+    }
     @ChildContent
 </ix-workflow-step>

--- a/SiemensIXBlazor/Components/Workflow/WorkflowStep.razor.cs
+++ b/SiemensIXBlazor/Components/Workflow/WorkflowStep.razor.cs
@@ -17,6 +17,8 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
+        public RenderFragment? CustomIcon { get; set; }
+        [Parameter]
         public bool Clickable { get; set; } = false;
         [Parameter]
         public bool Disabled { get; set; } = false;

--- a/SiemensIXBlazor/Components/Workflow/WorkflowSteps.razor
+++ b/SiemensIXBlazor/Components/Workflow/WorkflowSteps.razor
@@ -17,7 +17,6 @@
 @attributes="UserAttributes"
 id="@Id"
 clickable="@Clickable"
-linear="@Linear"
 selected-index="@SelectedIndex"
 vertical="@Vertical"
 style="@Style"

--- a/SiemensIXBlazor/Components/Workflow/WorkflowSteps.razor.cs
+++ b/SiemensIXBlazor/Components/Workflow/WorkflowSteps.razor.cs
@@ -22,8 +22,6 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool Clickable { get; set; } = false;
         [Parameter]
-        public bool Linear { get; set; } = false;
-        [Parameter]
         public int SelectedIndex { get; set; } = 0;
         [Parameter]
         public bool Vertical { get; set; } = false;


### PR DESCRIPTION
## 💡 What is the current behavior?

WorkflowStep does not expose the official custom icon slot, and WorkflowSteps exposes an unsupported linear parameter and attribute.

GitHub Issue Number: #274 

## 🆕 What is the new behavior?

- WorkflowStep supports custom icon content through the `CustomIcon` render fragment.
- WorkflowSteps no longer exposes or renders the unsupported `Linear` parameter.
- Tests and README examples cover the updated API.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)