### PR TITLE
feat(slider): align labels and validation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,9 +1178,20 @@ AddItemEvent="SelectItemAdded" Mode="SelectMode.Single" SelectedIndices="2" Id="
 ## Slider
 
 ```razor
-<Slider Id="slider-demo" Min="0" Max="50" Step="5" Value="0" Marker="[0, 10, 20, 30, 40, 50]">
-    <span slot="label-start">0</span>
-    <span slot="label-end">50</span>
+<Slider Id="slider-demo"
+        Label="Range"
+        HelperText="Select a value"
+        Min="0"
+        Max="50"
+        Step="5"
+        Value="0"
+        Marker="[0, 10, 20, 30, 40, 50]">
+    <LabelStart>
+        <span>0</span>
+    </LabelStart>
+    <LabelEnd>
+        <span>50</span>
+    </LabelEnd>
 </Slider>
 ```
 

--- a/SiemensIXBlazor.Tests/SliderTests.cs
+++ b/SiemensIXBlazor.Tests/SliderTests.cs
@@ -23,12 +23,23 @@ public class SliderTests : TestContextBase
     {
         // Arrange
         var id = "slider1";
-        var error = "error message";
+        var helperText = "Select a value";
+        var label = "Slider label";
+        var invalidText = "Invalid value";
+        var infoText = "Additional information";
+        var warningText = "Warning value";
+        var validText = "Valid value";
 
         var cut = RenderComponent<Slider>(parameters => parameters
             .Add(p => p.Id, id)
             .Add(p => p.Value, 42)
-            .Add<dynamic>(p => p.Error, error)
+            .Add(p => p.HelperText, helperText)
+            .Add(p => p.Label, label)
+            .Add(p => p.InvalidText, invalidText)
+            .Add(p => p.InfoText, infoText)
+            .Add(p => p.WarningText, warningText)
+            .Add(p => p.ValidText, validText)
+            .Add(p => p.ShowTextAsTooltip, true)
             .Add(p => p.Max, 100)
             .Add(p => p.Min, 0)
             .Add(p => p.Step, 1)
@@ -42,13 +53,31 @@ public class SliderTests : TestContextBase
                 id=""{id}"" 
                 value=""42"" 
                 disabled 
-                error=""{error}"" 
+                helper-text=""{helperText}""
+                label=""{label}""
+                invalid-text=""{invalidText}""
+                info-text=""{infoText}""
+                warning-text=""{warningText}""
+                valid-text=""{validText}""
+                show-text-as-tooltip
                 max=""100"" 
                 min=""0"" 
                 step=""1"" 
                 trace 
                 trace-reference=""5"">
             </ix-slider>");
+    }
+
+    [Fact]
+    public void Slider_RendersTypedLabelSlots()
+    {
+        var cut = RenderComponent<Slider>(parameters => parameters
+            .Add(p => p.Id, "slider-slots")
+            .Add(p => p.LabelStart, (RenderFragment)(builder => builder.AddContent(0, "Minimum")))
+            .Add(p => p.LabelEnd, (RenderFragment)(builder => builder.AddContent(0, "Maximum"))));
+
+        cut.MarkupMatches(@"
+            <ix-slider id=""slider-slots"" value=""0"" max=""100"" min=""0"" step=""1"" trace-reference=""0""><div slot=""label-start"">Minimum</div><div slot=""label-end"">Maximum</div></ix-slider>");
     }
 
     [Fact]

--- a/SiemensIXBlazor/Components/Slider/Slider.razor
+++ b/SiemensIXBlazor/Components/Slider/Slider.razor
@@ -18,11 +18,31 @@
            style="@Style" 
            value="@Value"
            disabled="@Disabled"
-           error="@(ErrorAsString)"
+           helper-text="@HelperText"
+           label="@Label"
+           invalid-text="@InvalidText"
+           info-text="@InfoText"
+           warning-text="@WarningText"
+           valid-text="@ValidText"
+           show-text-as-tooltip="@ShowTextAsTooltip"
            max="@Max"
            min="@Min"
            step="@Step"
            trace="@Trace"
            trace-reference="@TraceReference">
+    @if (LabelStart is not null)
+    {
+        <div slot="label-start">
+            @LabelStart
+        </div>
+    }
+
+    @if (LabelEnd is not null)
+    {
+        <div slot="label-end">
+            @LabelEnd
+        </div>
+    }
+
     @ChildContent
 </ix-slider>

--- a/SiemensIXBlazor/Components/Slider/Slider.razor.cs
+++ b/SiemensIXBlazor/Components/Slider/Slider.razor.cs
@@ -23,15 +23,23 @@ namespace SiemensIXBlazor.Components.Slider
         [Parameter]
         public bool Disabled { get; set; } = false;
         [Parameter]
-        public dynamic? Error { get; set; }
-        private string? ErrorAsString => Error switch
-        {
-            bool b => b.ToString().ToLowerInvariant(),
-            string s => s,
-            null => null,
-            _ => Error?.ToString()
-        };
-
+        public string? HelperText { get; set; }
+        [Parameter]
+        public string? Label { get; set; }
+        [Parameter]
+        public string? InvalidText { get; set; }
+        [Parameter]
+        public string? InfoText { get; set; }
+        [Parameter]
+        public string? WarningText { get; set; }
+        [Parameter]
+        public string? ValidText { get; set; }
+        [Parameter]
+        public bool ShowTextAsTooltip { get; set; } = false;
+        [Parameter]
+        public RenderFragment? LabelStart { get; set; }
+        [Parameter]
+        public RenderFragment? LabelEnd { get; set; }
         [Parameter]
         public double[]? Marker { get; set; }
         [Parameter]
@@ -39,7 +47,7 @@ namespace SiemensIXBlazor.Components.Slider
         [Parameter]
         public double Min { get; set; } = 0;
         [Parameter]
-        public double? Step { get; set; }
+        public double Step { get; set; } = 1;
         [Parameter]
         public bool Trace { get; set; } = false;
         [Parameter]


### PR DESCRIPTION
## 💡 What is the current behavior?

The Slider wrapper does not expose the official validation text properties or label slots and maps the unsupported `Error` parameter.

GitHub Issue Number: #268 

## 🆕 What is the new behavior?

- Slider exposes the official validation properties and `LabelStart`/`LabelEnd` slots.
- `Step` defaults to `1`, and the unsupported `Error` parameter is removed.
- Tests and README examples cover the updated API.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)