### PR TITLE
feat(pane): align layout slots and spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,24 +1111,28 @@ private void OnModalDismissed()
 
 ```razor
 <PaneLayout Id="pane-layout"
-                Variant="@PaneVariant.floating"
-                Layout="full-horizontal"
-                Borderless="true">
-    <Pane Id="pane1" Heading="Pane Left" Slot="left" Size="33%">
-        <p>This is the left pane.</p>
-    </Pane>
-
-    <Pane Id="pane2"  Heading="Pane Top" Slot="top" Size="33%">
-        <p>This is the top pane.</p>
-    </Pane>
-
-    <Pane Id="pane3" Heading="Pane Right" Slot="right" Size="33%">
-        <p>This is the right pane.</p>
-    </Pane>
-
-    <Pane Id="pane4" Heading="Pane Bottom" Slot="bottom" Size="33%">
-        <p>This is the bottom pane.</p>
-    <Pane>
+             Variant="@PaneVariant.floating"
+             Layout="full-horizontal"
+             Borderless="true">
+    <Left>
+        <Pane Id="pane-left" Heading="Pane Left" Slot="left" Size="33%">
+            <p>This is the left pane.</p>
+        </Pane>
+    </Left>
+    <Top>
+        <div>This is the top content.</div>
+    </Top>
+    <Content>
+        <div>This is the main content.</div>
+    </Content>
+    <Bottom>
+        <div>This is the bottom content.</div>
+    </Bottom>
+    <Right>
+        <Pane Id="pane-right" Heading="Pane Right" Slot="right" Size="33%" NoPadding="true">
+            <p>This pane has no content padding.</p>
+        </Pane>
+    </Right>
 </PaneLayout>
 ```
 

--- a/SiemensIXBlazor.Tests/PaneLayoutTest.cs
+++ b/SiemensIXBlazor.Tests/PaneLayoutTest.cs
@@ -31,5 +31,22 @@ namespace SiemensIXBlazor.Tests
             // Assert
             cut.MarkupMatches("<ix-pane-layout borderless layout=\"full-vertical\" variant=\"inline\"><div>Test content</div></ix-pane-layout>");
         }
+
+        [Fact]
+        public void PaneLayoutRendersNamedSlots()
+        {
+            var cut = RenderComponent<PaneLayout>(parameters => parameters
+                .Add(p => p.Left, builder => builder.AddContent(0, "Left content"))
+                .Add(p => p.Top, builder => builder.AddContent(0, "Top content"))
+                .Add(p => p.Content, builder => builder.AddContent(0, "Content area"))
+                .Add(p => p.Bottom, builder => builder.AddContent(0, "Bottom content"))
+                .Add(p => p.Right, builder => builder.AddContent(0, "Right content")));
+
+            Assert.Equal("Left content", cut.Find("[slot='left']").TextContent.Trim());
+            Assert.Equal("Top content", cut.Find("[slot='top']").TextContent.Trim());
+            Assert.Equal("Content area", cut.Find("[slot='content']").TextContent.Trim());
+            Assert.Equal("Bottom content", cut.Find("[slot='bottom']").TextContent.Trim());
+            Assert.Equal("Right content", cut.Find("[slot='right']").TextContent.Trim());
+        }
     }
 }

--- a/SiemensIXBlazor.Tests/PaneTest.cs
+++ b/SiemensIXBlazor.Tests/PaneTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
 using SiemensIXBlazor.Enums.Pane;
 using SiemensIXBlazor.Objects.Pane;
+using System.Text.Json;
 
 namespace SiemensIXBlazor.Tests
 {
@@ -24,6 +25,7 @@ namespace SiemensIXBlazor.Tests
             var cut = RenderComponent<Pane>(
                 ("Id", "testId"),
                 ("Borderless", true),
+                ("NoPadding", true),
                 ("Composition", PaneComposition.top),
                 ("Expanded", true),
                 ("CloseOnClickOutside", true),
@@ -36,7 +38,18 @@ namespace SiemensIXBlazor.Tests
             );
 
             // Assert
-            cut.MarkupMatches("<ix-pane id=\"testId\" borderless composition=\"top\" expanded close-on-click-outside=\"\" heading=\"Test Heading\" hide-on-collapse icon=\"Test Icon\" size=\"240px\" variant=\"inline\" aria-label-collapse-close-button=\"testAriaLabelCollapseCloseButton\"></ix-pane>");
+            cut.MarkupMatches("<ix-pane id=\"testId\" borderless composition=\"top\" expanded close-on-click-outside=\"\" heading=\"Test Heading\" hide-on-collapse icon=\"Test Icon\" size=\"240px\" variant=\"inline\" no-padding aria-label-collapse-close-button=\"testAriaLabelCollapseCloseButton\"></ix-pane>");
+        }
+
+        [Fact]
+        public void PaneUsesOfficialDefaultValues()
+        {
+            var cut = RenderComponent<Pane>(("Id", "default-pane"));
+
+            Assert.DoesNotContain("close-on-click-outside", cut.Markup);
+            Assert.DoesNotContain("no-padding", cut.Markup);
+            Assert.False(cut.Instance.CloseOnClickOutside);
+            Assert.False(cut.Instance.NoPadding);
         }
 
         [Fact]
@@ -121,6 +134,21 @@ namespace SiemensIXBlazor.Tests
 
             // Assert
             Assert.DoesNotContain("slot=\"header\"", cut.Markup);
+        }
+
+        [Fact]
+        public async Task ExpandedChangedDeserializesOfficialBooleanPayload()
+        {
+            PaneExpandedChangedEventResponse? response = null;
+            var cut = RenderComponent<Pane>(parameters => parameters
+                .Add(p => p.Id, "pane-event")
+                .Add(p => p.ExpandedChangedEvent, EventCallback.Factory.Create<PaneExpandedChangedEventResponse>(this, value => response = value)));
+
+            await cut.Instance.ExpandChanged(JsonDocument.Parse("{\"slot\":\"left\",\"expanded\":true}").RootElement);
+
+            Assert.NotNull(response);
+            Assert.Equal("left", response!.Slot);
+            Assert.True(response.Expanded);
         }
     }
 }

--- a/SiemensIXBlazor/Components/Pane/Pane.razor
+++ b/SiemensIXBlazor/Components/Pane/Pane.razor
@@ -20,7 +20,7 @@
 
 <ix-pane class="@Class" style="@Style" @attributes="UserAttributes" id="@Id"
          aria-label-icon="@AriaLabelIcon" aria-label-collapse-close-button="@AriaLabelCollapseCloseButton" close-on-click-outside="@CloseOnClickOutside" heading="@Heading"
-    composition="@(EnumParser<PaneComposition>.EnumToString(Composition))" size="@Size" borderless="@Borderless"
+    composition="@(EnumParser<PaneComposition>.EnumToString(Composition))" size="@Size" borderless="@Borderless" no-padding="@NoPadding"
     icon="@Icon" variant="@(EnumParser<PaneVariant>.EnumToString(Variant))" hide-on-collapse="@HideOnCollapse"
     expanded="@Expanded">
     @if (HeaderContent != null)

--- a/SiemensIXBlazor/Components/Pane/Pane.razor.cs
+++ b/SiemensIXBlazor/Components/Pane/Pane.razor.cs
@@ -30,9 +30,11 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public RenderFragment? HeaderContent { get; set; }
         [Parameter]
-        public bool CloseOnClickOutside { get; set; } = true;
+        public bool CloseOnClickOutside { get; set; } = false;
         [Parameter]
         public bool Borderless { get; set; } = false;
+        [Parameter]
+        public bool NoPadding { get; set; } = false;
         [Parameter]
         public PaneComposition Composition { get; set; } = PaneComposition.top;
         [Parameter]

--- a/SiemensIXBlazor/Components/PaneLayout/PaneLayout.razor
+++ b/SiemensIXBlazor/Components/PaneLayout/PaneLayout.razor
@@ -21,7 +21,42 @@
    @attributes="UserAttributes"
    variant="@Variant"
    layout="@Layout"
-   borderless="@Borderless"
+    borderless="@Borderless"
 >
+    @if (Left is not null)
+    {
+        <div slot="left">
+            @Left
+        </div>
+    }
+
+    @if (Top is not null)
+    {
+        <div slot="top">
+            @Top
+        </div>
+    }
+
+    @if (Content is not null)
+    {
+        <div slot="content">
+            @Content
+        </div>
+    }
+
     @ChildContent
+
+    @if (Bottom is not null)
+    {
+        <div slot="bottom">
+            @Bottom
+        </div>
+    }
+
+    @if (Right is not null)
+    {
+        <div slot="right">
+            @Right
+        </div>
+    }
 </ix-pane-layout>

--- a/SiemensIXBlazor/Components/PaneLayout/PaneLayout.razor.cs
+++ b/SiemensIXBlazor/Components/PaneLayout/PaneLayout.razor.cs
@@ -21,6 +21,16 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public PaneVariant Variant { get; set; } = PaneVariant.inline;
         [Parameter]
+        public RenderFragment? Left { get; set; }
+        [Parameter]
+        public RenderFragment? Top { get; set; }
+        [Parameter]
+        public RenderFragment? Content { get; set; }
+        [Parameter]
+        public RenderFragment? Bottom { get; set; }
+        [Parameter]
+        public RenderFragment? Right { get; set; }
+        [Parameter]
         public RenderFragment? ChildContent { get; set; }
 
     }

--- a/SiemensIXBlazor/Objects/Pane/PaneBorderlessChangedEventResponse.cs
+++ b/SiemensIXBlazor/Objects/Pane/PaneBorderlessChangedEventResponse.cs
@@ -14,8 +14,8 @@ namespace SiemensIXBlazor.Objects.Pane
     public  class PaneBorderlessChangedEventResponse
     {
         [JsonPropertyName("slot")]
-        public string Slot { get; set; }
+        public string Slot { get; set; } = string.Empty;
         [JsonPropertyName("borderless")]
-        public string Borderless { get; set; }
+        public bool Borderless { get; set; }
     }
 }

--- a/SiemensIXBlazor/Objects/Pane/PaneExpandedChangedEventResponse.cs
+++ b/SiemensIXBlazor/Objects/Pane/PaneExpandedChangedEventResponse.cs
@@ -14,8 +14,8 @@ namespace SiemensIXBlazor.Objects.Pane
     public  class PaneExpandedChangedEventResponse
     {
         [JsonPropertyName("slot")]
-        public string Slot { get; set; }
+        public string Slot { get; set; } = string.Empty;
         [JsonPropertyName("expanded")]
-        public string Expanded { get; set; }
+        public bool Expanded { get; set; }
     }
 }

--- a/SiemensIXBlazor/Objects/Pane/PaneVariantChangedEventResponse.cs
+++ b/SiemensIXBlazor/Objects/Pane/PaneVariantChangedEventResponse.cs
@@ -14,8 +14,8 @@ namespace SiemensIXBlazor.Objects.Pane
     public  class PaneVariantChangedEventResponse
     {
         [JsonPropertyName("slot")]
-        public string Slot { get; set; }
+        public string Slot { get; set; } = string.Empty;
         [JsonPropertyName("variant")]
-        public string Variant { get; set; }
+        public string Variant { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

Pane does not expose the official no-padding option, and PaneLayout does not provide named render fragments for its layout slots. Some Pane defaults and event payload types also differ from official IX.

GitHub Issue Number: #273 

## 🆕 What is the new behavior?

- Pane supports `NoPadding`, and PaneLayout exposes named `Left`, `Top`, `Content`, `Bottom`, and `Right` slots.
- Pane defaults and event payloads are aligned with official iX.
- Tests and README examples cover the updated API.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)