### PR TITLE
feat(message-bar): add close animation completion event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1056,7 +1056,10 @@ private void DrawerButtonClicked()
 ## Message bar
 
 ```razor
-<MessageBar ClosedChangeEvent="MessageboxClosed" Id="messagebar1" Type="MessageBarType.Info">
+<MessageBar ClosedChangeEvent="MessageboxClosed"
+            CloseAnimationCompletedEvent="MessageboxCloseAnimationCompleted"
+            Id="messagebar1"
+            Type="MessageBarType.Info">
     <div class="d-flex align-items-center justify-content-between">
         Message text <ix-button>Action</ix-button>
     </div>

--- a/SiemensIXBlazor.Tests/MessageBarTest.cs
+++ b/SiemensIXBlazor.Tests/MessageBarTest.cs
@@ -56,4 +56,21 @@ public class MessageBarTests : TestContextBase
         // Assert
         Assert.True(closed);
     }
+
+    [Fact]
+    public void CloseAnimationCompletedEventWorks()
+    {
+        // Arrange
+        var animationCompleted = false;
+        var cut = RenderComponent<MessageBar>(
+            ("Id", "messageBar"),
+            ("CloseAnimationCompletedEvent", EventCallback.Factory.Create(this, () => animationCompleted = true))
+        );
+
+        // Act
+        cut.Instance.CloseAnimationCompleted();
+
+        // Assert
+        Assert.True(animationCompleted);
+    }
 }

--- a/SiemensIXBlazor/Components/MessageBar/MessageBar.razor.cs
+++ b/SiemensIXBlazor/Components/MessageBar/MessageBar.razor.cs
@@ -27,6 +27,8 @@ namespace SiemensIXBlazor.Components
         public MessageBarType Type { get; set; } = MessageBarType.Info;
         [Parameter]
         public EventCallback ClosedChangeEvent { get; set; }
+        [Parameter]
+        public EventCallback CloseAnimationCompletedEvent { get; set; }
 
         private BaseInterop _interop;
 
@@ -37,6 +39,7 @@ namespace SiemensIXBlazor.Components
                 _interop = new(JSRuntime);
 
                 await _interop.AddEventListener(this, Id, "closedChange", "ClosedChange");
+                await _interop.AddEventListener(this, Id, "closeAnimationCompleted", "CloseAnimationCompleted");
             }
         }
 
@@ -44,6 +47,12 @@ namespace SiemensIXBlazor.Components
         public async void ClosedChange()
         {
             await ClosedChangeEvent.InvokeAsync();
-        } 
+        }
+
+        [JSInvokable]
+        public async void CloseAnimationCompleted()
+        {
+            await CloseAnimationCompletedEvent.InvokeAsync();
+        }
     }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

The MessageBar wrapper exposes the close-change callback but does not expose the official close-animation completion event.

GitHub Issue Number: #267 

## 🆕 What is the new behavior?

- Expose `CloseAnimationCompletedEvent`, mapped to the official `closeAnimationCompleted` event.
- Update tests and README examples for the new callback.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)