### PR TITLE
feat(radio-group): complete binding and direction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,20 @@ private void DrawerButtonClicked()
 <LinkButton Url="https://ix.siemens.io/">Siemens IX</LinkButton>
 ```
 
+## Radio group
+
+```razor
+<RadioGroup Id="storage-options"
+            Label="Storage options"
+            Direction="RadioGroupDirection.Row"
+            Value="512"
+            ValueChangeEvent="OnStorageChanged">
+    <Radio Label="256GB SSD storage" Value="256" Name="storage" />
+    <Radio Label="512GB SSD storage" Value="512" Name="storage" />
+    <Radio Label="1TB SSD storage" Value="1024" Name="storage" />
+</RadioGroup>
+```
+
 ## Message bar
 
 ```razor

--- a/SiemensIXBlazor.Tests/RadioGroupTest.cs
+++ b/SiemensIXBlazor.Tests/RadioGroupTest.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// SPDX-FileCopyrightText: 2024 Siemens AG
+// SPDX-FileCopyrightText: 2026 Siemens AG
 //
 // SPDX-License-Identifier: MIT
 //

--- a/SiemensIXBlazor.Tests/RadioGroupTest.cs
+++ b/SiemensIXBlazor.Tests/RadioGroupTest.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Text.Json;
+using SiemensIXBlazor.Components.Radio;
+using SiemensIXBlazor.Enums.Radio;
+
+namespace SiemensIXBlazor.Tests;
+
+public class RadioGroupTests : TestContextBase
+{
+    [Fact]
+    public void RendersPublicPropertiesAndChildContent()
+    {
+        var cut = RenderComponent<RadioGroup>(parameters => parameters
+            .Add(p => p.Id, "radio-group")
+            .Add(p => p.Label, "Storage options")
+            .Add(p => p.HelperText, "Choose one")
+            .Add(p => p.InfoText, "Info")
+            .Add(p => p.WarningText, "Warning")
+            .Add(p => p.ValidText, "Valid")
+            .Add(p => p.InvalidText, "Invalid")
+            .Add(p => p.ShowTextAsTooltip, true)
+            .Add(p => p.Value, "512")
+            .Add(p => p.Direction, RadioGroupDirection.Row)
+            .AddChildContent("Options"));
+
+        cut.MarkupMatches("<ix-radio-group id=\"radio-group\" label=\"Storage options\" helper-text=\"Choose one\" info-text=\"Info\" warning-text=\"Warning\" valid-text=\"Valid\" invalid-text=\"Invalid\" show-text-as-tooltip value=\"512\" direction=\"row\">Options</ix-radio-group>");
+    }
+
+    [Fact]
+    public void DirectionDefaultsToColumn()
+    {
+        var cut = RenderComponent<RadioGroup>(("Id", "radio-group"));
+
+        Assert.Equal(RadioGroupDirection.Column, cut.Instance.Direction);
+        Assert.Equal("column", cut.Find("ix-radio-group").GetAttribute("direction"));
+    }
+
+    [Fact]
+    public async Task ValueChangeEventUpdatesValueAndInvokesCallback()
+    {
+        string? received = null;
+        var cut = RenderComponent<RadioGroup>(parameters => parameters
+            .Add(p => p.Id, "radio-group")
+            .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<string>(this, value => received = value)));
+
+        await cut.Instance.ValueChange(JsonDocument.Parse("\"option-2\"").RootElement);
+
+        Assert.Equal("option-2", cut.Instance.Value);
+        Assert.Equal("option-2", received);
+    }
+}

--- a/SiemensIXBlazor/Components/Radio/RadioGroup.razor
+++ b/SiemensIXBlazor/Components/Radio/RadioGroup.razor
@@ -1,15 +1,22 @@
-﻿@using Microsoft.JSInterop;
+@using Microsoft.JSInterop;
 @using SiemensIXBlazor.Components
+@using SiemensIXBlazor.Enums.Radio
+@using SiemensIXBlazor.Helpers
 @inherits IXBaseComponent
 @inject IJSRuntime JSRuntime
 
-<ix-radio-group id="@Id"
+<ix-radio-group @attributes="UserAttributes"
+                class="@Class"
+                style="@Style"
+                id="@Id"
                 label="@Label"
+                helper-text="@HelperText"
                 info-text="@InfoText"
                 warning-text="@WarningText"
                 valid-text="@ValidText"
                 invalid-text="@InvalidText"
-                class="@CssClass"
-                direction="@Direction">
+                show-text-as-tooltip="@ShowTextAsTooltip"
+                value="@Value"
+                direction="@(EnumParser<RadioGroupDirection>.EnumToString(Direction))">
     @ChildContent
 </ix-radio-group>

--- a/SiemensIXBlazor/Components/Radio/RadioGroup.razor.cs
+++ b/SiemensIXBlazor/Components/Radio/RadioGroup.razor.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using SiemensIXBlazor.Enums.Radio;
+using SiemensIXBlazor.Interops;
+using System.Text.Json;
 
 namespace SiemensIXBlazor.Components.Radio
 {
@@ -9,6 +13,9 @@ namespace SiemensIXBlazor.Components.Radio
 
         [Parameter]
         public string? Label { get; set; }
+
+        [Parameter]
+        public string? HelperText { get; set; }
 
         [Parameter]
         public string? InfoText { get; set; }
@@ -22,14 +29,39 @@ namespace SiemensIXBlazor.Components.Radio
         [Parameter]
         public string? InvalidText { get; set; }
 
+        [Parameter]
+        public bool ShowTextAsTooltip { get; set; } = false;
 
         [Parameter]
-        public string? CssClass { get; set; }
+        public string? Value { get; set; }
 
         [Parameter]
-        public string? Direction { get; set; }
+        public RadioGroupDirection Direction { get; set; } = RadioGroupDirection.Column;
+
+        [Parameter]
+        public EventCallback<string> ValueChangeEvent { get; set; }
 
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
+
+        private BaseInterop? _interop;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                _interop = new(JSRuntime);
+                await _interop.AddEventListener(this, Id, "valueChange", "ValueChange");
+            }
+        }
+
+        [JSInvokable]
+        public async Task ValueChange(JsonElement valueState)
+        {
+            var newValue = valueState.GetString() ?? string.Empty;
+            Value = newValue;
+            await ValueChangeEvent.InvokeAsync(newValue);
+            await InvokeAsync(StateHasChanged);
+        }
     }
 }

--- a/SiemensIXBlazor/Enums/Radio/RadioGroupDirection.cs
+++ b/SiemensIXBlazor/Enums/Radio/RadioGroupDirection.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2024 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.Radio
+{
+    public enum RadioGroupDirection
+    {
+        Column,
+        Row
+    }
+}

--- a/SiemensIXBlazor/Enums/Radio/RadioGroupDirection.cs
+++ b/SiemensIXBlazor/Enums/Radio/RadioGroupDirection.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// SPDX-FileCopyrightText: 2024 Siemens AG
+// SPDX-FileCopyrightText: 2026 Siemens AG
 //
 // SPDX-License-Identifier: MIT
 //


### PR DESCRIPTION
## 💡 What is the current behavior?

RadioGroup does not expose the complete official iX API for value binding, validation text, tooltip display, or typed layout direction.

GitHub Issue Number: #243 

## 🆕 What is the new behavior?

- Add official RadioGroup properties, typed column/row direction, and string value binding.
- Expose the typed `ValueChangeEvent` callback and update tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)