### PR TITLE
feat(category-filter): align public API and interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,9 +583,11 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
     @ref="categoryFilter"
     Id="category-filter-1"
     Placeholder="Filter by"
-    RepeatCategories="false"
+    UniqueCategories="true"
     FilterChangedEvent="FilterStateChanged"
-    InputChangedEvent="InputStateChanged">
+    InputChangedEvent="InputStateChanged"
+    CategoryChangedEvent="CategoryStateChanged"
+    FilterClearedEvent="FilterCleared">
 </CategoryFilter>
 ```
 
@@ -593,6 +595,13 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
 CategoryFilter categoryFilter;
 Dictionary<string, Category> categoriesDict;
 FilterState filterState;
+
+void InputStateChanged(InputState state) { }
+void CategoryStateChanged(string? category) { }
+void FilterCleared(FilterClearedEventArgs eventArgs)
+{
+    // Set eventArgs.Cancel = true to keep the current filter.
+}
 
 protected override void OnAfterRender(bool firstRender)
     {
@@ -620,7 +629,7 @@ protected override void OnAfterRender(bool firstRender)
                     {
                         Id = "ID_1",
                         Value = "IBM",
-                        Operator = "Not Equal"
+                        Operator = LogicalFilterOperator.NotEqual
                     }
                 }
             };

--- a/SiemensIXBlazor.Tests/CategoryFilterTests.cs
+++ b/SiemensIXBlazor.Tests/CategoryFilterTests.cs
@@ -10,7 +10,9 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components.CategoryFilter;
+using SiemensIXBlazor.Enums.CategoryFilter;
 using SiemensIXBlazor.Objects;
+using System.Text.Json;
 
 namespace SiemensIXBlazor.Tests
 {
@@ -57,7 +59,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var cut = RenderComponent<CategoryFilter>();
-            var mockFilterState = new FilterState { Categories = [new FilterStateCategory { Id = "testId", Operator = "testOperator", Value = "testValue" }] };
+            var mockFilterState = new FilterState { Categories = [new FilterStateCategory { Id = "testId", Operator = LogicalFilterOperator.NotEqual, Value = "testValue" }] };
 
             // Act
             cut.Instance.FilterState = mockFilterState;
@@ -95,31 +97,104 @@ namespace SiemensIXBlazor.Tests
         }
 
         [Fact]
-        public void FilterChangedEventTriggeredCorrectly()
+        public async Task FilterChangedEventReceivesTypedState()
         {
-            // Arrange
-            var eventTriggered = false;
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters.Add(p => p.FilterChangedEvent, EventCallback.Factory.Create<FilterState>(this, () => eventTriggered = true)));
+            FilterState? received = null;
+            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+                .Add(p => p.FilterChangedEvent, EventCallback.Factory.Create<FilterState>(this, state => received = state)));
 
-            // Act
-            cut.Instance.FilterChangedEvent.InvokeAsync();
+            var payload = JsonDocument.Parse("""
+                {"tokens":["test"],"categories":[{"id":"vendor","value":"Siemens","operator":"Equal"}]}
+                """).RootElement;
+            await cut.Instance.FilterChanged(payload);
 
-            // Assert
-            Assert.True(eventTriggered);
+            Assert.Equal("test", received!.Tokens[0]);
+            Assert.Equal(LogicalFilterOperator.Equal, received.Categories[0].Operator);
         }
 
         [Fact]
-        public void InputChangedEventTriggeredCorrectly()
+        public async Task InputChangedEventReceivesTypedState()
         {
-            // Arrange
-            var eventTriggered = false;
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters.Add(p => p.InputChangedEvent, EventCallback.Factory.Create<dynamic>(this, () => eventTriggered = true)));
+            InputState? received = null;
+            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+                .Add(p => p.InputChangedEvent, EventCallback.Factory.Create<InputState>(this, state => received = state)));
 
-            // Act
-            cut.Instance.InputChangedEvent.InvokeAsync();
+            var payload = JsonDocument.Parse("""{"token":"Sie","category":"vendor"}""").RootElement;
+            await cut.Instance.InputChanged(payload);
 
-            // Assert
-            Assert.True(eventTriggered);
+            Assert.Equal("Sie", received!.Token);
+            Assert.Equal("vendor", received.Category);
+            Assert.True(received.HasCategory());
+        }
+
+        [Fact]
+        public async Task CategoryChangedEventPassesCategoryAndSupportsClear()
+        {
+            string? category = "not-set";
+            var cleared = false;
+            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+                .Add(p => p.CategoryChangedEvent, EventCallback.Factory.Create<string?>(this, value => category = value))
+                .Add(p => p.FilterClearedEvent, EventCallback.Factory.Create<FilterClearedEventArgs>(this, _ => cleared = true)));
+
+            await cut.Instance.CategoryChanged("category");
+            await cut.Instance.CategoryChanged(null);
+            var canceled = await cut.Instance.FilterCleared();
+
+            Assert.Null(category);
+            Assert.True(cleared);
+            Assert.False(canceled);
+        }
+
+        [Fact]
+        public async Task FilterClearedCanBeCanceled()
+        {
+            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+                .Add(p => p.FilterClearedEvent, EventCallback.Factory.Create<FilterClearedEventArgs>(this, eventArgs => eventArgs.Cancel = true)));
+
+            Assert.True(await cut.Instance.FilterCleared());
+        }
+
+        [Fact]
+        public void FilterStateUsesOfficialOperatorStrings()
+        {
+            var state = new FilterState
+            {
+                Categories = [new() { Id = "vendor", Value = "Siemens", Operator = LogicalFilterOperator.NotEqual }]
+            };
+
+            var json = JsonSerializer.Serialize(state);
+            var deserialized = JsonSerializer.Deserialize<FilterState>(json);
+
+            Assert.Contains("\"operator\":\"Not equal\"", json);
+            Assert.Equal(LogicalFilterOperator.NotEqual, deserialized!.Categories[0].Operator);
+        }
+
+        [Fact]
+        public void RepeatedEquivalentStateDoesNotCauseRecursiveRendering()
+        {
+            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+                .Add(p => p.Id, "category-filter"));
+
+            for (var index = 0; index < 100; index++)
+            {
+                cut.SetParametersAndRender(parameters => parameters
+                    .Add(p => p.Categories, new Dictionary<string, Category>
+                    {
+                        ["vendor"] = new() { Label = "Vendor", Options = ["Siemens"] }
+                    })
+                    .Add(p => p.FilterState, new FilterState
+                    {
+                        Tokens = ["test"],
+                        Categories = []
+                    })
+                    .Add(p => p.NonSelectableCategories, new Dictionary<string, string>
+                    {
+                        ["archived"] = "Archived"
+                    })
+                    .Add(p => p.Suggestions, ["test"]));
+            }
+
+            Assert.Equal("category-filter", cut.Instance.Id);
         }
 
         [Fact]

--- a/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
+++ b/SiemensIXBlazor/Components/CategoryFilter/CategoryFilter.razor.cs
@@ -9,54 +9,43 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using Newtonsoft.Json;
 using SiemensIXBlazor.Enums.CategoryFilter;
-using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Components.CategoryFilter
 {
-    public partial class CategoryFilter
+    public partial class CategoryFilter : IAsyncDisposable
     {
-        private Dictionary<string, Category>? _categories;
-        private FilterState? _filterState;
-        private Dictionary<string, string>? _nonSelectableCategories;
-        private string[] _suggestions = [];
         private Lazy<Task<IJSObjectReference>>? moduleTask;
-        private BaseInterop? _interop;
-        private LogicalFilterOperator _logicalFilterOperator = LogicalFilterOperator.Equal;
+        private DotNetObjectReference<CategoryFilter>? _objectReference;
+        private string? _initializedId;
+        private string? _categoriesSnapshot;
+        private string? _filterStateSnapshot;
+        private string? _nonSelectableCategoriesSnapshot;
+        private string? _suggestionsSnapshot;
+        private LogicalFilterOperator? _staticOperatorSnapshot;
+        private bool _categoriesChanged = true;
+        private bool _filterStateChanged = true;
+        private bool _nonSelectableCategoriesChanged = true;
+        private bool _suggestionsChanged = true;
+        private bool _staticOperatorChanged = true;
 
         [Parameter, EditorRequired]
         public string Id { get; set; } = string.Empty;
-        public Dictionary<string, Category>? Categories
-        {
-            get => _categories;
-            set
-            {
-                _categories = value;
-                InitialParameter("setCategories", _categories);
-            }
-        }
-        public FilterState? FilterState
-        {
-            get => _filterState;
-            set
-            {
-                if (value is not null)
-                {
-                    _filterState = value;
-                    InitialParameter("setFilterState", _filterState);
-                }
 
-            }
-        }
         [Parameter]
-        public bool? HideIcon { get; set; }
+        public Dictionary<string, Category>? Categories { get; set; }
+
+        [Parameter]
+        public FilterState? FilterState { get; set; }
+
+        [Parameter]
+        public bool HideIcon { get; set; } = false;
         [Parameter]
         public string I18nPlainText { get; set; } = "Filter by text";
         [Parameter]
-        public string Icon { get; set; } = "search";
+        public string? Icon { get; set; }
         [Parameter]
         public string LabelCategories { get; set; } = "Categories";
         [Parameter]
@@ -65,15 +54,10 @@ namespace SiemensIXBlazor.Components.CategoryFilter
         public string? AriaLabelOperatorButton { get; set; }
         [Parameter]
         public string? AriaLabelResetButton { get; set; }
-        public Dictionary<string, string>? NonSelectableCategories
-        {
-            get => _nonSelectableCategories;
-            set
-            {
-                _nonSelectableCategories = value;
-                InitialParameter("setNonSelectableCategories", _nonSelectableCategories);
-            }
-        }
+
+        [Parameter]
+        public Dictionary<string, string>? NonSelectableCategories { get; set; }
+
         [Parameter]
         public string? Placeholder { get; set; }
         [Parameter]
@@ -84,77 +68,185 @@ namespace SiemensIXBlazor.Components.CategoryFilter
         public bool EnableTopLayer { get; set; } = false;
         [Parameter]
         public bool Readonly { get; set; } = false;
-        [Parameter]
-        public string[]? Suggestions
-        {
-            get => _suggestions;
-            set
-            {
-                _suggestions = value;
-                InitialParameter("setSuggestions", new Dictionary<string, string[]> { { "suggestions", _suggestions } });
-            }
-        }
 
         [Parameter]
-        public LogicalFilterOperator StaticOperator
-        {
-            get => _logicalFilterOperator;
-            set
-            {
+        public string[]? Suggestions { get; set; }
 
-                _logicalFilterOperator = value;
-                InitialParameter("setStaticOperator", _logicalFilterOperator.ToEnumString());
-            }
-        }
+        [Parameter]
+        public LogicalFilterOperator? StaticOperator { get; set; }
+
+        [Parameter]
+        public EventCallback<string?> CategoryChangedEvent { get; set; }
+
         [Parameter]
         public EventCallback<FilterState> FilterChangedEvent { get; set; }
-        [Parameter]
-        public EventCallback<dynamic> InputChangedEvent { get; set; }
 
-        protected override void OnAfterRender(bool firstRender)
+        [Parameter]
+        public EventCallback<FilterClearedEventArgs> FilterClearedEvent { get; set; }
+
+        [Parameter]
+        public EventCallback<InputState> InputChangedEvent { get; set; }
+
+        protected override void OnParametersSet()
+        {
+            TrackChange(
+                Categories?.OrderBy(category => category.Key),
+                ref _categoriesSnapshot,
+                ref _categoriesChanged);
+            TrackChange(FilterState, ref _filterStateSnapshot, ref _filterStateChanged);
+            TrackChange(
+                NonSelectableCategories?.OrderBy(category => category.Key),
+                ref _nonSelectableCategoriesSnapshot,
+                ref _nonSelectableCategoriesChanged);
+            TrackChange(Suggestions, ref _suggestionsSnapshot, ref _suggestionsChanged);
+
+            if (_staticOperatorSnapshot != StaticOperator)
+            {
+                _staticOperatorSnapshot = StaticOperator;
+                _staticOperatorChanged = true;
+            }
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
-                _interop = new(JSRuntime);
-
-                Task.Run(async () =>
-                {
-                    await _interop.AddEventListener(this, Id, "filterChanged", "FilterChanged");
-                    await _interop.AddEventListener(this, Id, "inputChanged", "InputChanged");
-                });
+                moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/categoryFilterInterop.js").AsTask());
+                _objectReference = DotNetObjectReference.Create(this);
             }
+
+            var module = await GetModuleAsync();
+            if (!string.Equals(_initializedId, Id, StringComparison.Ordinal))
+            {
+                if (_initializedId is not null)
+                {
+                    await module.InvokeVoidAsync("dispose", _initializedId);
+                }
+
+                await module.InvokeVoidAsync("initialize", _objectReference, Id);
+                _initializedId = Id;
+                _categoriesChanged = true;
+                _filterStateChanged = true;
+                _nonSelectableCategoriesChanged = true;
+                _suggestionsChanged = true;
+                _staticOperatorChanged = true;
+            }
+
+            await ApplyParametersAsync(module);
         }
 
         [JSInvokable]
-        public async void FilterChanged(JsonElement filterState)
+        public async Task CategoryChanged(string? category)
         {
-            string jsonDataText = filterState.GetRawText();
-            FilterState? state = JsonConvert.DeserializeObject<FilterState>(jsonDataText);
+            await CategoryChangedEvent.InvokeAsync(category);
+        }
+
+        [JSInvokable]
+        public async Task FilterChanged(JsonElement filterState)
+        {
+            FilterState state = JsonSerializer.Deserialize<FilterState>(filterState.GetRawText()) ?? new();
             await FilterChangedEvent.InvokeAsync(state);
         }
 
         [JSInvokable]
-        public async void InputChanged(JsonElement inputState)
+        public async Task<bool> FilterCleared()
         {
-            string jsonDataText = inputState.GetRawText();
-            dynamic? state = JsonConvert.DeserializeObject<dynamic>(jsonDataText);
+            var eventArgs = new FilterClearedEventArgs();
+            await FilterClearedEvent.InvokeAsync(eventArgs);
+            return eventArgs.Cancel;
+        }
+
+        [JSInvokable]
+        public async Task InputChanged(JsonElement inputState)
+        {
+            InputState state = JsonSerializer.Deserialize<InputState>(inputState.GetRawText()) ?? new();
             await InputChangedEvent.InvokeAsync(state);
         }
 
-        private void InitialParameter(string functionName, object param)
+        private static void TrackChange<T>(T value, ref string? snapshot, ref bool changed)
         {
-
-            moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/categoryFilterInterop.js").AsTask());
-
-            Task.Run(async () =>
+            var currentSnapshot = JsonSerializer.Serialize(value);
+            if (!string.Equals(snapshot, currentSnapshot, StringComparison.Ordinal))
             {
-                var module = await moduleTask.Value;
-                if (module != null)
+                snapshot = currentSnapshot;
+                changed = true;
+            }
+        }
+
+        private async Task<IJSObjectReference> GetModuleAsync()
+        {
+            if (moduleTask is null)
+            {
+                throw new InvalidOperationException("CategoryFilter interop is not initialized.");
+            }
+
+            return await moduleTask.Value;
+        }
+
+        private async Task ApplyParametersAsync(IJSObjectReference module)
+        {
+            var categoriesChanged = _categoriesChanged;
+            var filterStateChanged = _filterStateChanged;
+            var nonSelectableCategoriesChanged = _nonSelectableCategoriesChanged;
+            var suggestionsChanged = _suggestionsChanged;
+            var staticOperatorChanged = _staticOperatorChanged;
+
+            _categoriesChanged = false;
+            _filterStateChanged = false;
+            _nonSelectableCategoriesChanged = false;
+            _suggestionsChanged = false;
+            _staticOperatorChanged = false;
+
+            if (categoriesChanged)
+            {
+                await module.InvokeVoidAsync("setCategories", Id, Categories);
+            }
+
+            if (filterStateChanged)
+            {
+                await module.InvokeVoidAsync("setFilterState", Id, FilterState);
+            }
+
+            if (nonSelectableCategoriesChanged)
+            {
+                await module.InvokeVoidAsync("setNonSelectableCategories", Id, NonSelectableCategories);
+            }
+
+            if (suggestionsChanged)
+            {
+                await module.InvokeVoidAsync("setSuggestions", Id, Suggestions);
+            }
+
+            if (staticOperatorChanged)
+            {
+                await module.InvokeVoidAsync(
+                    "setStaticOperator",
+                    Id,
+                    StaticOperator?.ToEnumString());
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (moduleTask is not null && moduleTask.IsValueCreated)
+            {
+                try
                 {
-                    await module.InvokeVoidAsync(functionName, Id, JsonConvert.SerializeObject(param));
+                    var module = await moduleTask.Value;
+                    if (_initializedId is not null)
+                    {
+                        await module.InvokeVoidAsync("dispose", _initializedId);
+                    }
+                    await module.DisposeAsync();
                 }
-            });
+                catch (JSDisconnectedException)
+                {
+                }
+            }
+
+            _objectReference?.Dispose();
+            GC.SuppressFinalize(this);
         }
 
     }

--- a/SiemensIXBlazor/Enums/CategoryFilter/LogicalFilterOperatorJsonConverter.cs
+++ b/SiemensIXBlazor/Enums/CategoryFilter/LogicalFilterOperatorJsonConverter.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SiemensIXBlazor.Enums.CategoryFilter
+{
+    public sealed class LogicalFilterOperatorJsonConverter : JsonConverter<LogicalFilterOperator>
+    {
+        public override LogicalFilterOperator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetString() switch
+            {
+                "Equal" => LogicalFilterOperator.Equal,
+                "Not equal" => LogicalFilterOperator.NotEqual,
+                var value => throw new JsonException($"Unsupported logical filter operator '{value}'.")
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, LogicalFilterOperator value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToEnumString());
+        }
+    }
+}

--- a/SiemensIXBlazor/Enums/CategoryFilter/LogicalFiterOperator.cs
+++ b/SiemensIXBlazor/Enums/CategoryFilter/LogicalFiterOperator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace SiemensIXBlazor.Enums.CategoryFilter
 {
+    [System.Text.Json.Serialization.JsonConverter(typeof(LogicalFilterOperatorJsonConverter))]
     public enum LogicalFilterOperator
     {
         Equal,

--- a/SiemensIXBlazor/Objects/Category.cs
+++ b/SiemensIXBlazor/Objects/Category.cs
@@ -7,15 +7,15 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace SiemensIXBlazor.Objects
 {
     public class Category
     {
-        [JsonProperty("label")]
-        public string? Label { get; set; }
-        [JsonProperty("options")]
-        public string[]? Options { get; set; }
+        [JsonPropertyName("label")]
+        public string Label { get; set; } = string.Empty;
+        [JsonPropertyName("options")]
+        public string[] Options { get; set; } = [];
     }
 }

--- a/SiemensIXBlazor/Objects/FilterClearedEventArgs.cs
+++ b/SiemensIXBlazor/Objects/FilterClearedEventArgs.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Objects
+{
+    public class FilterClearedEventArgs : EventArgs
+    {
+        public bool Cancel { get; set; }
+    }
+}

--- a/SiemensIXBlazor/Objects/FilterState.cs
+++ b/SiemensIXBlazor/Objects/FilterState.cs
@@ -7,15 +7,15 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace SiemensIXBlazor.Objects
 {
     public class FilterState
     {
-        [JsonProperty("tokens")]
-        public string[]? Tokens { get; set; }
-        [JsonProperty("categories")]
-        public FilterStateCategory[]? Categories { get; set; }
+        [JsonPropertyName("tokens")]
+        public string[] Tokens { get; set; } = [];
+        [JsonPropertyName("categories")]
+        public FilterStateCategory[] Categories { get; set; } = [];
     }
 }

--- a/SiemensIXBlazor/Objects/FilterStateCategory.cs
+++ b/SiemensIXBlazor/Objects/FilterStateCategory.cs
@@ -7,17 +7,18 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using SiemensIXBlazor.Enums.CategoryFilter;
+using System.Text.Json.Serialization;
 
 namespace SiemensIXBlazor.Objects
 {
     public class FilterStateCategory
     {
-        [JsonProperty("id")]
-        public string? Id { get; set; }
-        [JsonProperty("value")]
-        public string? Value { get; set; }
-        [JsonProperty("operator")]
-        public string? Operator { get; set; }
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("value")]
+        public string Value { get; set; } = string.Empty;
+        [JsonPropertyName("operator")]
+        public LogicalFilterOperator Operator { get; set; } = LogicalFilterOperator.Equal;
     }
 }

--- a/SiemensIXBlazor/Objects/InputState.cs
+++ b/SiemensIXBlazor/Objects/InputState.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace SiemensIXBlazor.Objects
+{
+    public class InputState
+    {
+        [JsonPropertyName("token")]
+        public string Token { get; set; } = string.Empty;
+
+        [JsonPropertyName("category")]
+        public string? Category { get; set; } = string.Empty;
+
+        public bool HasCategory() => Category is not null;
+    }
+}

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/categoryFilterInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/categoryFilterInterop.js
@@ -7,13 +7,75 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
+function getElement(id) {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Element with ID ${id} not found`);
+  }
+  return element;
+}
+
+const listeners = new Map();
+
+export function initialize(caller, id) {
+  dispose(id);
+
+  const element = getElement(id);
+  let resumeClear = false;
+  let clearPending = false;
+  let active = true;
+
+  const categoryChanged = (event) => caller.invokeMethodAsync("CategoryChanged", event.detail ?? null);
+  const filterChanged = (event) => caller.invokeMethodAsync("FilterChanged", event.detail);
+  const inputChanged = (event) => caller.invokeMethodAsync("InputChanged", event.detail);
+  const filterCleared = async (event) => {
+    if (resumeClear) {
+      resumeClear = false;
+      return;
+    }
+
+    event.preventDefault();
+    if (clearPending) {
+      return;
+    }
+
+    clearPending = true;
+    try {
+      const cancel = await caller.invokeMethodAsync("FilterCleared");
+      if (!cancel && active && element.isConnected) {
+        const resetButton = element.shadowRoot?.querySelector(".reset-button");
+        if (resetButton) {
+          resumeClear = true;
+          resetButton.click();
+        }
+      }
+    } finally {
+      clearPending = false;
+    }
+  };
+
+  element.addEventListener("categoryChanged", categoryChanged);
+  element.addEventListener("filterChanged", filterChanged);
+  element.addEventListener("inputChanged", inputChanged);
+  element.addEventListener("filterCleared", filterCleared);
+
+  listeners.set(id, () => {
+    active = false;
+    element.removeEventListener("categoryChanged", categoryChanged);
+    element.removeEventListener("filterChanged", filterChanged);
+    element.removeEventListener("inputChanged", inputChanged);
+    element.removeEventListener("filterCleared", filterCleared);
+  });
+}
+
+export function dispose(id) {
+  listeners.get(id)?.();
+  listeners.delete(id);
+}
+
 export function setCategories(id, categories) {
   try {
-    const element = document.getElementById(id);
-    if (!element) {
-      throw new Error(`Element with ID ${id} not found`);
-    }
-    element.categories = JSON.parse(categories);
+    getElement(id).categories = categories ?? undefined;
   } catch (err) {
     console.error("Failed to set categories:", err);
   }
@@ -21,11 +83,7 @@ export function setCategories(id, categories) {
 
 export function setFilterState(id, filterState) {
   try {
-    const element = document.getElementById(id);
-    if (!element) {
-      throw new Error(`Element with ID ${id} not found`);
-    }
-    element.filterState = JSON.parse(filterState);
+    getElement(id).filterState = filterState ?? undefined;
   } catch (err) {
     console.error("Failed to set filter state:", err);
   }
@@ -33,35 +91,23 @@ export function setFilterState(id, filterState) {
 
 export function setNonSelectableCategories(id, nonSelectableCategories) {
   try {
-    const element = document.getElementById(id);
-    if (!element) {
-      throw new Error(`Element with ID ${id} not found`);
-    }
-    element.nonSelectableCategories = JSON.parse(nonSelectableCategories);
-  } catch {
+    getElement(id).nonSelectableCategories = nonSelectableCategories ?? undefined;
+  } catch (error) {
     console.error("Failed to set non-selectable categories:", error);
   }
 }
 
 export function setSuggestions(id, suggestionsObject) {
   try {
-    const element = document.getElementById(id);
-    if (!element) {
-      throw new Error(`Element with ID ${id} not found`);
-    }
-    element.suggestions = JSON.parse(suggestionsObject).suggestions;
-  } catch {
+    getElement(id).suggestions = suggestionsObject ?? undefined;
+  } catch (error) {
     console.error("Failed to set suggestions:", error);
   }
 }
 
 export function setStaticOperator(id, logicalFilter) {
     try {
-        const element = document.getElementById(id);
-        if (!element) {
-            throw new Error(`Element with ID ${id} not found`);
-        }
-        element.staticOperator = JSON.parse(logicalFilter);
+        getElement(id).staticOperator = logicalFilter ?? undefined;
     } catch (err) {
         console.error("Failed on setting staticOperator", err);
     }


### PR DESCRIPTION
## 💡 What is the current behavior?

The `CategoryFilter` wrapper had incomplete typing, redundant interop updates, and no way to cancel the official `filterCleared` event.

GitHub Issue Number: #266 

## 🆕 What is the new behavior?

- Added typed CategoryFilter properties and event payloads aligned with official IX.
- Added cancelable `FilterClearedEvent` handling and optimized interop lifecycle management.
- Updated tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)