### PR TITLE
feat(upload): align directory and file states

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,8 @@ tree.TreeModel = treeNodes;
 
 ```razor
 <Upload Id="file-upload-test"
+        DirectoryUpload="true"
+        State="UploadFileState.SELECT_FILE"
         FileChangedEvent="(data) => FileChanged(data)">
 </Upload>
 ```

--- a/SiemensIXBlazor.Tests/UploadTest.cs
+++ b/SiemensIXBlazor.Tests/UploadTest.cs
@@ -10,7 +10,9 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.Upload;
 using SiemensIXBlazor.Objects;
+using System.Text.Json;
 using Xunit;
 
 namespace SiemensIXBlazor.Tests
@@ -30,36 +32,57 @@ namespace SiemensIXBlazor.Tests
                 ("LoadingText", "Checking files…"),
                 ("Multiline", true),
                 ("Multiple", true),
+                ("DirectoryUpload", true),
+                ("State", UploadFileState.UPLOAD_FAILED),
                 ("SelectFileText", "+ Drag files here or…"),
                 ("UploadFailedText", "Upload failed. Please try again."),
                 ("UploadSuccessText", "Upload successful")
             );
 
             // Assert
-            cut.MarkupMatches("<ix-upload id=\"testId\" accept=\"image/*\" disabled i18n-upload-disabled=\"File upload currently not possible.\" i18n-upload-file=\"Upload file…\" loading-text=\"Checking files…\" multiline multiple select-file-text=\"+ Drag files here or…\" upload-failed-text=\"Upload failed. Please try again.\" upload-success-text=\"Upload successful\"></ix-upload>");
+            cut.MarkupMatches("<ix-upload id=\"testId\" accept=\"image/*\" disabled i18n-upload-disabled=\"File upload currently not possible.\" i18n-upload-file=\"Upload file…\" loading-text=\"Checking files…\" multiline multiple directory-upload state=\"UPLOAD_FAILED\" select-file-text=\"+ Drag files here or…\" upload-failed-text=\"Upload failed. Please try again.\" upload-success-text=\"Upload successful\"></ix-upload>");
+        }
+
+        [Fact]
+        public void DirectoryUploadUsesOfficialDefaultState()
+        {
+            var cut = RenderComponent<Upload>(parameters => parameters
+                .Add(p => p.Id, "folder-upload")
+                .Add(p => p.DirectoryUpload, true));
+
+            cut.MarkupMatches("<ix-upload id=\"folder-upload\" directory-upload state=\"SELECT_FILE\" i18n-upload-disabled=\"File upload currently not possible.\" upload-failed-text=\"Upload failed. Please try again.\" upload-success-text=\"Upload successful\"></ix-upload>");
         }
 
         [Fact]
         public async Task FileChangedEventWorks()
         {
             // Arrange
-            var fileChanged = false;
+            IXFile? changedFile = null;
             var cut = RenderComponent<Upload>(parameters => parameters
                 .Add(p => p.Id, "upload")
-                .Add(p => p.FileChangedEvent, EventCallback.Factory.Create<List<IXFile>>(this, newValue => { fileChanged = true; }))
+                .Add(p => p.FileChangedEvent, EventCallback.Factory.Create<List<IXFile>>(this, newValue => { changedFile = newValue.Single(); }))
             );
 
             // Simulate the file change event
-            var files = new object[] {
-                new { name = "file1.txt", size = 1234L, type = "text/plain", data = "base64EncodedData" }
+            var files = new[]
+            {
+                JsonSerializer.SerializeToElement(new
+                {
+                    name = "file1.txt",
+                    size = 1234L,
+                    type = "text/plain",
+                    data = "base64EncodedData"
+                })
             };
 
-            await cut.Instance.FileChangedEvent.InvokeAsync(new List<IXFile>());
-
-
+            await cut.Instance.FileChanged(files);
 
             // Assert
-            Assert.True(fileChanged);
+            Assert.NotNull(changedFile);
+            Assert.Equal("file1.txt", changedFile!.Name);
+            Assert.Equal(1234L, changedFile.Size);
+            Assert.Equal("text/plain", changedFile.Type);
+            Assert.Equal("base64EncodedData", changedFile.Base64Data);
         }
     }
 }

--- a/SiemensIXBlazor/Components/Upload/Upload.razor
+++ b/SiemensIXBlazor/Components/Upload/Upload.razor
@@ -9,6 +9,8 @@
 *@
 
 @using Microsoft.JSInterop;
+@using SiemensIXBlazor.Enums.Upload;
+@using SiemensIXBlazor.Helpers;
 @inject IJSRuntime JSRuntime
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
@@ -23,6 +25,8 @@ i18n-upload-file="@I18nUploadFile"
 loading-text="@LoadingText"
 multiline="@Multiline"
 multiple="@Multiple"
+directory-upload="@DirectoryUpload"
+state="@(EnumParser<UploadFileState>.EnumToString(State, toLowerCase: false))"
 select-file-text="@SelectFileText"
 upload-failed-text="@UploadFailedText"
 upload-success-text="@UploadSuccessText"

--- a/SiemensIXBlazor/Components/Upload/Upload.razor.cs
+++ b/SiemensIXBlazor/Components/Upload/Upload.razor.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects;
+using SiemensIXBlazor.Enums.Upload;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Components
@@ -26,15 +27,19 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string I18nUploadDisabled { get; set; } = "File upload currently not possible.";
         [Parameter]
-        public string I18nUploadFile { get; set; } = "Upload file…";
+        public string? I18nUploadFile { get; set; }
         [Parameter]
-        public string LoadingText { get; set; } = "Checking files…";
+        public bool DirectoryUpload { get; set; } = false;
+        [Parameter]
+        public UploadFileState State { get; set; } = UploadFileState.SELECT_FILE;
+        [Parameter]
+        public string? LoadingText { get; set; }
         [Parameter]
         public bool Multiline { get; set; } = false;
         [Parameter]
         public bool Multiple { get; set; } = false;
         [Parameter]
-        public string SelectFileText { get; set; } = "+ Drag files here or…";
+        public string? SelectFileText { get; set; }
         [Parameter]
         public string UploadFailedText { get; set; } = "Upload failed. Please try again.";
         [Parameter]
@@ -42,7 +47,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public EventCallback<List<IXFile>> FileChangedEvent { get; set; }
 
-        FileUploadInterop _fileUploadInterop;
+        private FileUploadInterop? _fileUploadInterop;
 
         protected async override Task OnAfterRenderAsync(bool firstRender)
         {
@@ -55,25 +60,31 @@ namespace SiemensIXBlazor.Components
         }
 
         [JSInvokable]
-        public async void FileChanged(object[] files)
+        public async Task FileChanged(JsonElement[] files)
         {
             var ixFiles = ParseFileObject(files);
             await FileChangedEvent.InvokeAsync(ixFiles);
         }
 
-        private static List<IXFile> ParseFileObject(object[] fileObjects)
+        public async Task SetFilesToUploadAsync(object files)
+        {
+            _fileUploadInterop ??= new(JSRuntime);
+            await _fileUploadInterop.SetFilesToUpload(Id, files);
+        }
+
+        private static List<IXFile> ParseFileObject(IEnumerable<JsonElement> fileObjects)
         {
             List<IXFile> ixFiles = new();
 
             foreach (var fileObj in fileObjects)
             {
-                var fileData = (JsonElement)fileObj;
+                var fileData = fileObj;
 
                 // Extract file properties and base64 data
-                string fileName = fileData.GetProperty("name").GetString();
+                string fileName = fileData.GetProperty("name").GetString() ?? string.Empty;
                 long fileSize = fileData.GetProperty("size").GetInt64();
-                string fileType = fileData.GetProperty("type").GetString();
-                string base64Data = fileData.GetProperty("data").GetString();
+                string fileType = fileData.GetProperty("type").GetString() ?? string.Empty;
+                string base64Data = fileData.GetProperty("data").GetString() ?? string.Empty;
 
                 // Create a custom implementation of IBrowserFile
                 IXFile ixFile = new(fileName, fileSize, fileType, base64Data);

--- a/SiemensIXBlazor/Enums/Upload/UploadFileState.cs
+++ b/SiemensIXBlazor/Enums/Upload/UploadFileState.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.Upload;
+
+public enum UploadFileState
+{
+    SELECT_FILE,
+    LOADING,
+    UPLOAD_FAILED,
+    UPLOAD_SUCCESSED
+}

--- a/SiemensIXBlazor/Interops/FileUploadInterop.cs
+++ b/SiemensIXBlazor/Interops/FileUploadInterop.cs
@@ -28,6 +28,12 @@ namespace SiemensIXBlazor.Interops
             await module.InvokeAsync<string>("fileUploadEventHandler", objectReference, id, eventName, callbackFunctionName);
         }
 
+        public async Task SetFilesToUpload(string id, object files)
+        {
+            var module = await moduleTask.Value;
+            await module.InvokeVoidAsync("setFilesToUpload", id, files);
+        }
+
         public async ValueTask DisposeAsync()
         {
             if (moduleTask.IsValueCreated)

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/fileUploadInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/fileUploadInterop.js
@@ -57,3 +57,13 @@ export function fileUploadEventHandler(
       });
   });
 }
+
+export function setFilesToUpload(elementId, files) {
+  const element = document.getElementById(elementId);
+
+  if (!element || typeof element.setFilesToUpload !== "function") {
+    throw new Error(`Upload element with id ${elementId} not found.`);
+  }
+
+  return element.setFilesToUpload(files);
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

Upload does not expose the official directory upload, file state, or `setFilesToUpload` APIs.

GitHub Issue Number: #258 

## 🆕 What is the new behavior?

- Added directory upload and typed `UploadFileState` support.
- Added `SetFilesToUploadAsync` interop and aligned official text defaults.
- Updated tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)