### PR TITLE
feat(layout): type column sizes and add layout auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,14 +1037,27 @@ private void DrawerButtonClicked()
 ```razor
 <LayoutGrid>
   <Row>
-    <Col><ix-typography format="display">1</ix-typography></Col>
-    <Col><ix-typography format="display">2</ix-typography></Col>
-    <Col><ix-typography format="display">3</ix-typography></Col>
-    <Col><ix-typography format="display">4</ix-typography></Col>
-    <Col><ix-typography format="display">5</ix-typography></Col>
-    <Col><ix-typography format="display">6</ix-typography></Col>
+    <Col Size="ColumnSize._6">First column</Col>
+    <Col Size="ColumnSize._6">Second column</Col>
   </Row>
 </LayoutGrid>
+```
+
+## Layout Auto
+
+```razor
+<LayoutAuto Id="layout-auto-example" Layout="@Layout">
+  <Input Label="First name" />
+  <Input Label="Last name" />
+</LayoutAuto>
+
+@code {
+  private LayoutAutoItem[] Layout =
+  [
+    new() { MinWidth = "0", Columns = 1 },
+    new() { MinWidth = "48em", Columns = 2 }
+  ];
+}
 ```
 
 ## Link Button

--- a/SiemensIXBlazor.Tests/LayoutAuto/LayoutAutoTests.cs
+++ b/SiemensIXBlazor.Tests/LayoutAuto/LayoutAutoTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Components.LayoutAuto;
+using SiemensIXBlazor.Objects.LayoutAuto;
+using System.Text.Json;
+
+namespace SiemensIXBlazor.Tests.LayoutAutoComponent;
+
+public class LayoutAutoTests : TestContextBase
+{
+    [Fact]
+    public void ComponentRendersChildContentAndId()
+    {
+        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+            .Add(p => p.Id, "layout-auto")
+            .Add(p => p.ChildContent, (RenderFragment)(builder =>
+                builder.AddMarkupContent(0, "Test content"))));
+
+        cut.MarkupMatches("<ix-layout-auto id=\"layout-auto\">Test content</ix-layout-auto>");
+    }
+
+    [Fact]
+    public void LayoutDefaultsMatchOfficialValues()
+    {
+        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+            .Add(p => p.Id, "layout-auto"));
+
+        Assert.Equal(
+            [
+                new LayoutAutoItem { MinWidth = "0", Columns = 1 },
+                new LayoutAutoItem { MinWidth = "48em", Columns = 2 }
+            ],
+            cut.Instance.Layout,
+            LayoutAutoItemComparer.Instance);
+    }
+
+    [Fact]
+    public void LayoutAcceptsCustomBreakpointObjects()
+    {
+        var layout = new[]
+        {
+            new LayoutAutoItem { MinWidth = "0", Columns = 1 },
+            new LayoutAutoItem { MinWidth = "64em", Columns = 3 }
+        };
+
+        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+            .Add(p => p.Id, "layout-auto")
+            .Add(p => p.Layout, layout));
+
+        Assert.Same(layout, cut.Instance.Layout);
+    }
+
+    [Fact]
+    public void LayoutItemsSerializeWithOfficialPropertyNames()
+    {
+        var layout = new[]
+        {
+            new LayoutAutoItem { MinWidth = "48em", Columns = 2 }
+        };
+
+        Assert.Equal(
+            "[{\"minWidth\":\"48em\",\"columns\":2}]",
+            JsonSerializer.Serialize(layout));
+    }
+
+    private sealed class LayoutAutoItemComparer : IEqualityComparer<LayoutAutoItem>
+    {
+        public static LayoutAutoItemComparer Instance { get; } = new();
+
+        public bool Equals(LayoutAutoItem? x, LayoutAutoItem? y) =>
+            x is not null && y is not null &&
+            x.MinWidth == y.MinWidth && x.Columns == y.Columns;
+
+        public int GetHashCode(LayoutAutoItem obj) =>
+            HashCode.Combine(obj.MinWidth, obj.Columns);
+    }
+}

--- a/SiemensIXBlazor.Tests/LayoutGrid/ColTest.cs
+++ b/SiemensIXBlazor.Tests/LayoutGrid/ColTest.cs
@@ -9,6 +9,7 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.LayoutGrid;
 using SiemensIXBlazor.Components.LayoutGrid;
 
 namespace SiemensIXBlazor.Tests.LayoutGrid;
@@ -21,12 +22,29 @@ public class ColTest : TestContextBase
         // Arrange
         var cut = RenderComponent<Col>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
-            .Add(p => p.Size, "12")
-            .Add(p => p.SizeLg, "10")
-            .Add(p => p.SizeMd, "8")
-            .Add(p => p.SizeSm, "6"));
+            .Add(p => p.Size, ColumnSize._12)
+            .Add(p => p.SizeLg, ColumnSize._10)
+            .Add(p => p.SizeMd, ColumnSize._8)
+            .Add(p => p.SizeSm, ColumnSize._6));
 
         // Assert
         cut.MarkupMatches("<ix-col size=\"12\" size-lg=\"10\" size-md=\"8\" size-sm=\"6\">Test content</ix-col>");
+    }
+
+    [Fact]
+    public void ComponentRendersWithoutSizeAttributesByDefault()
+    {
+        var cut = RenderComponent<Col>();
+
+        cut.MarkupMatches("<ix-col></ix-col>");
+    }
+
+    [Fact]
+    public void ComponentRendersAutoColumnSize()
+    {
+        var cut = RenderComponent<Col>(parameters => parameters
+            .Add(p => p.Size, ColumnSize.auto));
+
+        cut.MarkupMatches("<ix-col size=\"auto\"></ix-col>");
     }
 }

--- a/SiemensIXBlazor.Tests/LayoutGrid/LayoutGridTest.cs
+++ b/SiemensIXBlazor.Tests/LayoutGrid/LayoutGridTest.cs
@@ -9,6 +9,7 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.LayoutGrid;
 
 namespace SiemensIXBlazor.Tests.LayoutGrid;
 
@@ -21,7 +22,7 @@ public class LayoutGridTest : TestContextBase
         var cut = RenderComponent<Components.LayoutGrid.LayoutGrid>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Columns, 12)
-            .Add(p => p.Gap, "24")
+            .Add(p => p.Gap, LayoutGridGap._24)
             .Add(p => p.NoMargin, false));
 
         // Assert

--- a/SiemensIXBlazor/Components/LayoutAuto/LayoutAuto.razor
+++ b/SiemensIXBlazor/Components/LayoutAuto/LayoutAuto.razor
@@ -1,5 +1,5 @@
-﻿@* -----------------------------------------------------------------------
-// SPDX-FileCopyrightText: 2024 Siemens AG
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
 //
 // SPDX-License-Identifier: MIT
 //
@@ -8,13 +8,14 @@
 //  -----------------------------------------------------------------------
 *@
 
-@using SiemensIXBlazor.Enums.LayoutGrid
+@using Microsoft.JSInterop
+@inject IJSRuntime JSRuntime
+@implements IAsyncDisposable
 @inherits IXBaseComponent
-<ix-layout-grid @attributes="UserAttributes"
+
+<ix-layout-auto @attributes="UserAttributes"
                 class="@Class"
                 style="@Style"
-                columns="@Columns"
-                gap="@Gap.ToAttributeValue()"
-                no-margin="@NoMargin">
+                id="@Id">
     @ChildContent
-</ix-layout-grid>
+</ix-layout-auto>

--- a/SiemensIXBlazor/Components/LayoutAuto/LayoutAuto.razor.cs
+++ b/SiemensIXBlazor/Components/LayoutAuto/LayoutAuto.razor.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Interops;
+using SiemensIXBlazor.Objects.LayoutAuto;
+
+namespace SiemensIXBlazor.Components.LayoutAuto;
+
+public partial class LayoutAuto
+{
+    private static LayoutAutoItem[] CreateDefaultLayout() =>
+    [
+        new() { MinWidth = "0", Columns = 1 },
+        new() { MinWidth = "48em", Columns = 2 }
+    ];
+
+    private BaseInterop? _interop;
+    private LayoutAutoItem[]? _appliedLayout;
+
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+
+    [Parameter]
+    public LayoutAutoItem[] Layout { get; set; } = CreateDefaultLayout();
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_interop is not null)
+        {
+            await ApplyLayoutAsync();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interop = new(JSRuntime);
+            await ApplyLayoutAsync();
+        }
+    }
+
+    private async Task ApplyLayoutAsync()
+    {
+        var layout = Layout ?? [];
+        if (_appliedLayout is not null &&
+            _appliedLayout.SequenceEqual(layout, LayoutAutoItemComparer.Instance))
+        {
+            return;
+        }
+
+        await _interop!.SetElementProperty(Id, "layout", layout);
+        _appliedLayout = layout
+            .Select(item => new LayoutAutoItem
+            {
+                MinWidth = item.MinWidth,
+                Columns = item.Columns
+            })
+            .ToArray();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_interop is not null)
+        {
+            await _interop.DisposeAsync();
+        }
+    }
+
+    private sealed class LayoutAutoItemComparer : IEqualityComparer<LayoutAutoItem>
+    {
+        public static LayoutAutoItemComparer Instance { get; } = new();
+
+        public bool Equals(LayoutAutoItem? x, LayoutAutoItem? y) =>
+            x is not null && y is not null &&
+            x.MinWidth == y.MinWidth && x.Columns == y.Columns;
+
+        public int GetHashCode(LayoutAutoItem obj) =>
+            HashCode.Combine(obj.MinWidth, obj.Columns);
+    }
+}

--- a/SiemensIXBlazor/Components/LayoutGrid/Col.razor
+++ b/SiemensIXBlazor/Components/LayoutGrid/Col.razor
@@ -8,13 +8,14 @@
 //  -----------------------------------------------------------------------
 *@
 
+@using SiemensIXBlazor.Enums.LayoutGrid
 @inherits IXBaseComponent
 <ix-col @attributes="UserAttributes"
         class="@Class"
         style="@Style"
-        size="@Size"
-        size-lg="@SizeLg"
-        size-md="@SizeMd"
-        size-sm="@SizeSm">
+        size="@(Size?.ToAttributeValue())"
+        size-lg="@(SizeLg?.ToAttributeValue())"
+        size-md="@(SizeMd?.ToAttributeValue())"
+        size-sm="@(SizeSm?.ToAttributeValue())">
     @ChildContent
 </ix-col>

--- a/SiemensIXBlazor/Components/LayoutGrid/Col.razor.cs
+++ b/SiemensIXBlazor/Components/LayoutGrid/Col.razor.cs
@@ -8,6 +8,7 @@
 //  -----------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.LayoutGrid;
 
 namespace SiemensIXBlazor.Components.LayoutGrid
 {
@@ -16,12 +17,12 @@ namespace SiemensIXBlazor.Components.LayoutGrid
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
-        public string? Size { get; set; }
+        public ColumnSize? Size { get; set; }
         [Parameter]
-        public string? SizeLg { get; set; }
+        public ColumnSize? SizeLg { get; set; }
         [Parameter]
-        public string? SizeMd { get; set; }
+        public ColumnSize? SizeMd { get; set; }
         [Parameter]
-        public string? SizeSm { get; set; }
+        public ColumnSize? SizeSm { get; set; }
     }
 }

--- a/SiemensIXBlazor/Components/LayoutGrid/LayoutGrid.razor.cs
+++ b/SiemensIXBlazor/Components/LayoutGrid/LayoutGrid.razor.cs
@@ -8,6 +8,7 @@
 //  -----------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.LayoutGrid;
 
 namespace SiemensIXBlazor.Components.LayoutGrid
 {
@@ -18,7 +19,7 @@ namespace SiemensIXBlazor.Components.LayoutGrid
         [Parameter]
         public int Columns { get; set; } = 12;
         [Parameter]
-        public string Gap { get; set; } = "24";
+        public LayoutGridGap Gap { get; set; } = LayoutGridGap._24;
         [Parameter]
         public bool NoMargin { get; set; } = false;
     }

--- a/SiemensIXBlazor/Enums/LayoutGrid/ColumnSize.cs
+++ b/SiemensIXBlazor/Enums/LayoutGrid/ColumnSize.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.LayoutGrid;
+
+public enum ColumnSize
+{
+    _1 = 1,
+    _2 = 2,
+    _3 = 3,
+    _4 = 4,
+    _5 = 5,
+    _6 = 6,
+    _7 = 7,
+    _8 = 8,
+    _9 = 9,
+    _10 = 10,
+    _11 = 11,
+    _12 = 12,
+    auto
+}

--- a/SiemensIXBlazor/Enums/LayoutGrid/LayoutGridExtensions.cs
+++ b/SiemensIXBlazor/Enums/LayoutGrid/LayoutGridExtensions.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace SiemensIXBlazor.Enums.LayoutGrid;
+
+public static class LayoutGridExtensions
+{
+    public static string ToAttributeValue(this ColumnSize size) =>
+        size == ColumnSize.auto ? "auto" : ((int)size).ToString(CultureInfo.InvariantCulture);
+
+    public static string ToAttributeValue(this LayoutGridGap gap) =>
+        ((int)gap).ToString(CultureInfo.InvariantCulture);
+}

--- a/SiemensIXBlazor/Enums/LayoutGrid/LayoutGridGap.cs
+++ b/SiemensIXBlazor/Enums/LayoutGrid/LayoutGridGap.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.LayoutGrid;
+
+public enum LayoutGridGap
+{
+    _8 = 8,
+    _12 = 12,
+    _16 = 16,
+    _24 = 24
+}

--- a/SiemensIXBlazor/Objects/LayoutAuto/LayoutAutoItem.cs
+++ b/SiemensIXBlazor/Objects/LayoutAuto/LayoutAutoItem.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace SiemensIXBlazor.Objects.LayoutAuto;
+
+public sealed class LayoutAutoItem
+{
+    [JsonPropertyName("minWidth")]
+    public string MinWidth { get; set; } = string.Empty;
+
+    [JsonPropertyName("columns")]
+    public int Columns { get; set; }
+}

--- a/SiemensIXBlazor/SiemensIXBlazor.csproj
+++ b/SiemensIXBlazor/SiemensIXBlazor.csproj
@@ -66,6 +66,7 @@
 	<ItemGroup>
 		<Folder Include="wwwroot\js\siemens-ix\" />
 		<Folder Include="Components\KeyValueList\" />
+		<Folder Include="Components\LayoutAuto\" />
 		<Folder Include="Components\KeyValue\" />
 		<Folder Include="Components\EmptyState\" />
 		<Folder Include="Components\PushCard\" />


### PR DESCRIPTION
## 💡 What is the current behavior?

Col size properties accept unrestricted strings, and the LayoutAuto wrapper is missing.

GitHub Issue Number: #245

## 🆕 What is the new behavior?

- Add typed column sizes, official grid gaps, and the LayoutAuto wrapper with breakpoint configuration.
- Update tests and README examples for numeric, auto, default, and custom layouts.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)