### PR TITLE
feat(toggle-search): align toggles and expanding search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,14 +1297,23 @@ await toast.ShowToast(configWithAction);
 ## Toggle Buttons
 
 ```razor
-<ToggleButton>Normal</ToggleButton>
-<ToggleButton Id="toggle-btn-1" Pressed="true">Pressed</ToggleButton>
+<ToggleButton Id="toggle-btn-1" Variant="ToggleButtonVariant.subtle_secondary">
+    Normal
+</ToggleButton>
+<ToggleButton Id="toggle-btn-2" Pressed="true" Icon="star">
+    Pressed
+</ToggleButton>
 
-<IconToggleButton Outline="true" Icon="checkboxes"></IconToggleButton>
+<IconToggleButton Icon="checkboxes"
+                   Variant="ButtonVariant.subtle_secondary"
+                   Size="IconButtonSize._16"
+                   Pressed="true"
+                   aria-label="Toggle checkboxes">
+</IconToggleButton>
 <IconToggleButton
     Outline="true"
     Icon="checkboxes"
-    Pressed="true"
+    aria-label="Toggle checkboxes outline"
 ></IconToggleButton>
 ```
 

--- a/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
+++ b/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
@@ -10,7 +10,7 @@
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using SiemensIXBlazor.Components;
-using SiemensIXBlazor.Enums.ExpandingSearch;
+using SiemensIXBlazor.Enums.Button;
 
 namespace SiemensIXBlazor.Tests;
 
@@ -26,14 +26,15 @@ public class ExpandingSearchTest : TestContextBase
             .Add(p => p.Placeholder, "testPlaceholder")
             .Add(p => p.Value, "testValue")
             .Add(p => p.FullWidth, true)
-            .Add(p => p.Outline, true)
-            .Add(p => p.Ghost, false)
-            .Add(p => p.Variant, ExpandingSearchVariant.secondary)
+            .Add(p => p.AriaLabelClearIconButton, "Clear")
+            .Add(p => p.AriaLabelSearchIconButton, "Search")
+            .Add(p => p.AriaLabelSearchInput, "Search field")
+            .Add(p => p.Variant, ButtonVariant.subtle_secondary)
             );
 
         // Assert
         cut.MarkupMatches(
-            "<ix-expanding-search placeholder=\"testPlaceholder\" icon=\"testIcon\" id=\"testId\" value=\"testValue\" full-width outline variant='secondary'></ix-expanding-search>");
+            "<ix-expanding-search placeholder=\"testPlaceholder\" icon=\"testIcon\" id=\"testId\" value=\"testValue\" aria-label-clear-icon-button=\"Clear\" aria-label-search-icon-button=\"Search\" aria-label-search-input=\"Search field\" full-width variant=\"subtle-secondary\"></ix-expanding-search>");
     }
 
     [Fact]

--- a/SiemensIXBlazor.Tests/ToggleButton/IconToggleButtonTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleButton/IconToggleButtonTest.cs
@@ -29,13 +29,13 @@ namespace SiemensIXBlazor.Tests.ToggleButton
                 ("Loading", true),
                 ("Outline", true),
                 ("Pressed", true),
-                ("Size", "24"),
-                ("Variant", ButtonVariant.secondary),
+                ("Size", IconButtonSize._16),
+                ("Variant", ButtonVariant.subtle_secondary),
                 ("Oval", true)
             );
 
             // Assert
-            cut.MarkupMatches("<ix-icon-toggle-button id=\"testId\" disabled ghost icon=\"test-icon\" loading outline pressed size=\"24\" variant=\"secondary\" oval></ix-icon-toggle-button>");
+            cut.MarkupMatches("<ix-icon-toggle-button id=\"testId\" disabled ghost icon=\"test-icon\" loading outline pressed size=\"16\" variant=\"subtle-secondary\" oval></ix-icon-toggle-button>");
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace SiemensIXBlazor.Tests.ToggleButton
             );
 
             // Act
-            await cut.Instance.PressedChangeEvent.InvokeAsync(true);
+            await cut.Instance.PressedChange(true);
 
             // Assert
             Assert.True(pressedChanged);

--- a/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
@@ -9,7 +9,7 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using SiemensIXBlazor.Enums.Button;
+using SiemensIXBlazor.Enums.ToggleButton;
 using Xunit;
 
 namespace SiemensIXBlazor.Tests.ToggleButton
@@ -27,11 +27,11 @@ namespace SiemensIXBlazor.Tests.ToggleButton
                 ("IconRight", "test-icon-right"),
                 ("Loading", true),
                 ("Pressed", true),
-                ("Variant", ButtonVariant.secondary)
+                ("Variant", ToggleButtonVariant.subtle_secondary)
             );
 
             // Assert
-            cut.MarkupMatches("<ix-toggle-button id=\"testId\" disabled icon=\"test-icon\" icon-right=\"test-icon-right\" loading pressed variant=\"secondary\"></ix-toggle-button>");
+            cut.MarkupMatches("<ix-toggle-button id=\"testId\" disabled icon=\"test-icon\" icon-right=\"test-icon-right\" loading pressed variant=\"subtle-secondary\"></ix-toggle-button>");
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace SiemensIXBlazor.Tests.ToggleButton
             );
 
             // Act
-            cut.Instance.PressedChange(true);
+            await cut.Instance.PressedChange(true);
 
             // Assert
             Assert.True(pressedChanged);

--- a/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor
+++ b/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor
@@ -11,7 +11,7 @@
 @using Microsoft.JSInterop;
 @inject IJSRuntime JSRuntime
 @using SiemensIXBlazor.Helpers;
-@using SiemensIXBlazor.Enums.ExpandingSearch;
+@using SiemensIXBlazor.Enums.Button;
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
 <ix-expanding-search @attributes="UserAttributes"
@@ -25,7 +25,5 @@
                      aria-label-search-icon-button="@AriaLabelSearchIconButton"
                      aria-label-search-input="@AriaLabelSearchInput"
                      full-width="@FullWidth"
-                     outline="@Outline"
-                     ghost="@Ghost"
-                     variant="@(EnumParser<ExpandingSearchVariant>.EnumToString(Variant))">
+                     variant="@(EnumParser<ButtonVariant>.EnumToString(Variant, replaceUnderscores: true))">
 </ix-expanding-search>

--- a/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor.cs
+++ b/SiemensIXBlazor/Components/ExpandingSearch/ExpandingSearch.razor.cs
@@ -9,7 +9,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using SiemensIXBlazor.Enums.ExpandingSearch;
+using SiemensIXBlazor.Enums.Button;
 using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components
@@ -25,19 +25,15 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? AriaLabelSearchInput { get; set; }   
         [Parameter] 
-        public string Icon { get; set; } = "search";
+        public string? Icon { get; set; }
         [Parameter]
         public string Placeholder { get; set; } = "Enter text here";
         [Parameter]
         public string Value { get; set; } = string.Empty;
         [Parameter]
-        public bool Ghost { get; set; } = true;
-        [Parameter]
-        public bool Outline { get; set; } = false;
-        [Parameter]
         public bool FullWidth { get; set; } = false;
         [Parameter]
-        public ExpandingSearchVariant Variant { get; set; } = ExpandingSearchVariant.primary;
+        public ButtonVariant Variant { get; set; } = ButtonVariant.tertiary;
         [Parameter]
         public EventCallback<string> ValueChangedEvent { get; set; }
 

--- a/SiemensIXBlazor/Components/ToggleButton/IconToggleButton.razor
+++ b/SiemensIXBlazor/Components/ToggleButton/IconToggleButton.razor
@@ -11,6 +11,8 @@
 @namespace SiemensIXBlazor.Components
 @using SiemensIXBlazor.Enums.Button;
 @using SiemensIXBlazor.Helpers;
+@using Microsoft.JSInterop;
+@inject IJSRuntime JSRuntime
 @inherits IXBaseComponent
 <ix-icon-toggle-button @attributes="UserAttributes" 
                         class="@Class" 
@@ -19,11 +21,10 @@
                        disabled="@Disabled"
                        ghost="@Ghost"
                         icon="@Icon"
-                       aria-label-icon-button="@AriaLabelIconButton"
                        loading="@Loading"
                        outline="@Outline"
                         pressed="@Pressed" 
-                        size="@Size"
+                       size="@((int)Size)"
                        variant="@(EnumParser<ButtonVariant>.EnumToString(Variant, replaceUnderscores: true))"
                         oval="@Oval">
 </ix-icon-toggle-button>

--- a/SiemensIXBlazor/Components/ToggleButton/IconToggleButton.razor.cs
+++ b/SiemensIXBlazor/Components/ToggleButton/IconToggleButton.razor.cs
@@ -8,7 +8,9 @@
 //  -----------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using SiemensIXBlazor.Enums.Button;
+using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components
 {
@@ -16,10 +18,6 @@ namespace SiemensIXBlazor.Components
     {
         [Parameter, EditorRequired]
         public string Id { get; set; }
-        [Parameter]
-        public string? AriaLabelIconButton { get; set; }   
-        [Parameter]
-        public RenderFragment? ChildContent { get; set; }
         [Parameter]
         public bool Disabled { get; set; } = false;
         [Parameter]
@@ -33,12 +31,30 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool Pressed { get; set; } = false;
         [Parameter]
-        public string Size { get; set; } = "24";
+        public IconButtonSize Size { get; set; } = IconButtonSize._24;
         [Parameter]
-        public ButtonVariant Variant { get; set; } = ButtonVariant.secondary;
+        public ButtonVariant Variant { get; set; } = ButtonVariant.subtle_primary;
         [Parameter]
         public bool Oval { get; set; } = false;
         [Parameter]
         public EventCallback<bool> PressedChangeEvent { get; set; }
+
+        private BaseInterop _interop;
+
+        protected async override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                _interop = new(JSRuntime);
+
+                await _interop.AddEventListener(this, Id, "pressedChange", "PressedChange");
+            }
+        }
+
+        [JSInvokable]
+        public async Task PressedChange(bool value)
+        {
+            await PressedChangeEvent.InvokeAsync(value);
+        }
     }
 }

--- a/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor
+++ b/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor
@@ -9,7 +9,7 @@
 *@
 
 @using Microsoft.JSInterop;
-@using SiemensIXBlazor.Enums.Button;
+@using SiemensIXBlazor.Enums.ToggleButton;
 @using SiemensIXBlazor.Helpers;
 @inject IJSRuntime JSRuntime
 @inherits IXBaseComponent
@@ -19,11 +19,10 @@
                   style="@Style" 
                   id="@Id" 
                   disabled="@Disabled"
-                  aria-label-icon-button="@AriaLabelIconButton"
                   icon="@Icon" 
                   icon-right="@IconRight"
                   loading="@Loading" 
                   pressed="@Pressed"
-                  variant="@(EnumParser<ButtonVariant>.EnumToString(Variant, replaceUnderscores: true))">
+                  variant="@(EnumParser<ToggleButtonVariant>.EnumToString(Variant, replaceUnderscores: true))">
    @ChildContent
 </ix-toggle-button>

--- a/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor.cs
+++ b/SiemensIXBlazor/Components/ToggleButton/ToggleButton.razor.cs
@@ -9,7 +9,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using SiemensIXBlazor.Enums.Button;
+using SiemensIXBlazor.Enums.ToggleButton;
 using SiemensIXBlazor.Interops;
 
 namespace SiemensIXBlazor.Components.ToggleButton
@@ -21,8 +21,6 @@ namespace SiemensIXBlazor.Components.ToggleButton
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
         [Parameter]
-        public string? AriaLabelIconButton { get; set; }
-        [Parameter]
         public bool Disabled { get; set; } = false;
         [Parameter]
         public string? Icon { get; set; }
@@ -33,7 +31,7 @@ namespace SiemensIXBlazor.Components.ToggleButton
         [Parameter]
         public bool Pressed { get; set; } = false;
         [Parameter]
-        public ButtonVariant Variant { get; set; } = ButtonVariant.secondary;
+        public ToggleButtonVariant Variant { get; set; } = ToggleButtonVariant.subtle_primary;
         [Parameter]
         public EventCallback<bool> PressedChangeEvent { get; set; }
 
@@ -50,7 +48,7 @@ namespace SiemensIXBlazor.Components.ToggleButton
         }
 
         [JSInvokable]
-        public async void PressedChange(bool value)
+        public async Task PressedChange(bool value)
         {
             await PressedChangeEvent.InvokeAsync(value);
         }

--- a/SiemensIXBlazor/Enums/ToggleButton/ToggleButtonVariant.cs
+++ b/SiemensIXBlazor/Enums/ToggleButton/ToggleButtonVariant.cs
@@ -1,5 +1,5 @@
-﻿// -----------------------------------------------------------------------
-// SPDX-FileCopyrightText: 2025 Siemens AG
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
 //
 // SPDX-License-Identifier: MIT
 //
@@ -7,10 +7,14 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-namespace SiemensIXBlazor.Enums.ExpandingSearch;
-public enum ExpandingSearchVariant
+namespace SiemensIXBlazor.Enums.ToggleButton;
+
+public enum ToggleButtonVariant
 {
     primary,
     secondary,
-    danger
+    tertiary,
+    subtle_primary,
+    subtle_secondary,
+    subtle_tertiary
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

`ToggleButton`, `IconToggleButton`, and `ExpandingSearch` were not fully aligned with the official IX public APIs. Some properties, defaults, variants, ARIA attributes, and rendered attributes were unsupported.

GitHub Issue Number: #249

## 🆕 What is the new behavior?

- Align `ToggleButton`, `IconToggleButton`, and `ExpandingSearch` with the official public API and behavior.
- Update typed properties, defaults, pressed-change events, tests, README examples, and test coverage.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)