### PR TITLE
feat(toast): complete toast lifecycle and container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,32 +1266,36 @@ private async Task OnChangeTab(int index)
 ## Toast
 
 ```razor
-<Toast @ref="toast"></Toast>
+<ToastContainer @ref="toastContainer" Id="toast-container" Position="ToastPosition.TopRight" />
+
+<Toast Id="toast"
+       Type="ToastType.Success"
+       ToastTitle="Changes applied"
+       PreventAutoClose="true">
+    <ChildContent>Your settings were saved successfully.</ChildContent>
+    <ActionContent>
+        <ix-button variant="tertiary">Undo</ix-button>
+    </ActionContent>
+</Toast>
 ```
 
 ```csharp
-private Toast toast;
+private ToastContainer toastContainer = default!;
+private ToastResult? toastResult;
 
-ToastConfig config = new ToastConfig()
-{
-    Message = "Test message",
-    Position = ToastPosition.BottomRight,
-    Type = "info"
-};
-
-await toast.ShowToast(config);
-
-ToastConfig configWithAction = new ToastConfig()
+toastResult = await toastContainer.ShowToast(new ToastConfig
 {
     Title = "Changes applied",
-    Message = "<div>Your settings were saved successfully.</div>",
-    Action = "<ix-button variant=\"tertiary\" icon=\"undo\">Undo</ix-button>",
-    Type = "success",
-    AutoClose = true,
-    AutoCloseDelay = 5000
-};
+    Message = "Your settings were saved successfully.",
+    Type = ToastType.Success,
+    AutoClose = false
+});
 
-await toast.ShowToast(configWithAction);
+toastResult.OnClose += (_, _) => Console.WriteLine("Toast closed");
+
+await toastResult.PauseAsync();
+await toastResult.ResumeAsync();
+await toastResult.CloseAsync();
 ```
 
 ## Toggle Buttons

--- a/SiemensIXBlazor.Tests/ToastTests.cs
+++ b/SiemensIXBlazor.Tests/ToastTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2025 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -7,7 +7,9 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
+using System.Text.Json;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Moq;
@@ -16,340 +18,218 @@ using SiemensIXBlazor.Components;
 using SiemensIXBlazor.Enums;
 using SiemensIXBlazor.Objects;
 
-namespace SiemensIXBlazor.Tests
+namespace SiemensIXBlazor.Tests;
+
+public class ToastTests : TestContextBase
 {
-    public class ToastTests : TestContextBase
+    [Fact]
+    public void ToastContainer_RendersOfficialDefaults()
     {
-        [Fact]
-        public void ComponentRendersWithoutCrashing()
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container"));
+
+        var container = cut.Find("ix-toast-container");
+        Assert.Equal("toast-container", container.Id);
+        Assert.Equal("bottom-right", container.GetAttribute("position"));
+    }
+
+    [Fact]
+    public void ToastContainer_RendersTopRightPositionAndAttributes()
+    {
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container")
+            .Add(p => p.Position, ToastPosition.TopRight)
+            .AddUnmatched("role", "region")
+            .Add(p => p.Class, "custom-container")
+            .Add(p => p.Style, "inset: 1rem;"));
+
+        var container = cut.Find("ix-toast-container");
+        Assert.Equal("top-right", container.GetAttribute("position"));
+        Assert.Equal("region", container.GetAttribute("role"));
+        Assert.Equal("custom-container", container.GetAttribute("class"));
+        Assert.Equal("inset: 1rem;", container.GetAttribute("style"));
+    }
+
+    [Fact]
+    public void Toast_RendersOfficialPropertiesAndSlots()
+    {
+        var cut = RenderComponent<Toast>(parameters => parameters
+            .Add(p => p.Id, "toast")
+            .Add(p => p.Type, ToastType.Success)
+            .Add(p => p.ToastTitle, "Saved")
+            .Add(p => p.AutoCloseDelay, 3000)
+            .Add(p => p.PreventAutoClose, true)
+            .Add(p => p.Icon, "save")
+            .Add(p => p.IconColor, "color-success")
+            .Add(p => p.HideIcon, true)
+            .Add(p => p.AriaLabelCloseIconButton, "Close notification")
+            .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddContent(0, "The message")))
+            .Add(p => p.ActionContent, (RenderFragment)(builder => builder.AddContent(0, "Undo"))));
+
+        var toast = cut.Find("ix-toast");
+        Assert.Equal("toast", toast.Id);
+        Assert.Equal("success", toast.GetAttribute("type"));
+        Assert.Equal("Saved", toast.GetAttribute("toast-title"));
+        Assert.Equal("3000", toast.GetAttribute("auto-close-delay"));
+        Assert.NotNull(toast.GetAttribute("prevent-auto-close"));
+        Assert.Equal("save", toast.GetAttribute("icon"));
+        Assert.Equal("color-success", toast.GetAttribute("icon-color"));
+        Assert.NotNull(toast.GetAttribute("hide-icon"));
+        Assert.Equal("Close notification", toast.GetAttribute("aria-label-close-icon-button"));
+        Assert.Contains("The message", toast.InnerHtml);
+        Assert.Contains("Undo", cut.Find("[slot='action']").InnerHtml);
+    }
+
+    [Fact]
+    public void Toast_OmitsFalseBooleanProperties()
+    {
+        var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
+
+        var toast = cut.Find("ix-toast");
+        Assert.Null(toast.GetAttribute("prevent-auto-close"));
+        Assert.Null(toast.GetAttribute("hide-icon"));
+    }
+
+    [Fact]
+    public async Task Toast_CloseToastInvokesCallback()
+    {
+        var closed = false;
+        var cut = RenderComponent<Toast>(parameters => parameters
+            .Add(p => p.Id, "toast")
+            .Add(p => p.CloseToastEvent, EventCallback.Factory.Create(this, () => closed = true)));
+
+        await cut.Instance.CloseToast();
+
+        Assert.True(closed);
+    }
+
+    [Fact]
+    public async Task Toast_ExposesPauseResumeAndIsPausedMethods()
+    {
+        var (jsRuntime, module) = AddJsModule();
+        module.Setup(m => m.InvokeAsync<bool>("isToastPaused", It.IsAny<object[]>()))
+            .Returns(new ValueTask<bool>(true));
+
+        var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
+
+        await cut.Instance.PauseAsync();
+        await cut.Instance.ResumeAsync();
+        var isPaused = await cut.Instance.IsPausedAsync();
+
+        Assert.True(isPaused);
+        module.Verify(m => m.InvokeAsync<bool>("isToastPaused", It.Is<object[]>(args => args.SequenceEqual(new object[] { "toast" }))), Times.Once);
+        _ = jsRuntime;
+    }
+
+    [Fact]
+    public async Task ToastContainer_ShowToastReturnsLifecycleHandle()
+    {
+        var (_, module) = AddJsModule();
+        module.Setup(m => m.InvokeAsync<string>("showToast", It.IsAny<object[]>()))
+            .Returns(new ValueTask<string>("toast-1"));
+        module.Setup(m => m.InvokeAsync<bool>("isPaused", It.IsAny<object[]>()))
+            .Returns(new ValueTask<bool>(true));
+
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container"));
+        var result = await cut.Instance.ShowToast(new ToastConfig
         {
-            // Arrange
-            var cut = RenderComponent<Toast>();
+            Title = "Saved",
+            Message = "The changes were saved.",
+            Action = "<button>Undo</button>",
+            Type = ToastType.Success,
+            AutoClose = false,
+            AutoCloseDelay = 3000,
+            Icon = "save",
+            IconColor = "color-success",
+            HideIcon = false
+        });
 
-            // Assert
-            cut.MarkupMatches("<ix-toast-container></ix-toast-container>");
-        }
+        await result.PauseAsync();
+        await result.ResumeAsync();
+        Assert.True(await result.IsPausedAsync());
+        await result.CloseAsync("undone");
 
-        [Fact]
-        public void UserAttributesAreAppliedCorrectly()
+        module.Verify(m => m.InvokeAsync<string>("showToast", It.Is<object[]>(args =>
+            args.Length == 3 && args[1] != null && args[1].ToString() == "toast-container" &&
+            args[2] != null && Convert.ToString(args[2])!.Contains("\"type\":\"success\""))), Times.Once);
+        module.Verify(m => m.InvokeAsync<bool>("isPaused", It.Is<object[]>(args => args.SequenceEqual(new object[] { "toast-1" }))), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToastContainer_OnCloseForwardsResultAndRemovesHandle()
+    {
+        var (_, module) = AddJsModule();
+        module.Setup(m => m.InvokeAsync<string>("showToast", It.IsAny<object[]>()))
+            .Returns(new ValueTask<string>("toast-1"));
+
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container"));
+        var result = await cut.Instance.ShowToast(new ToastConfig { Message = "Message" });
+        JsonElement? received = null;
+        result.OnClose += (_, value) => received = value;
+
+        using var document = JsonDocument.Parse("\"closed\"");
+        await cut.Instance.ToastClosed("toast-1", document.RootElement);
+
+        Assert.Equal("closed", received?.GetString());
+    }
+
+    [Fact]
+    public async Task ToastContainer_RejectsNullConfiguration()
+    {
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container"));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => cut.Instance.ShowToast(null!));
+    }
+
+    [Fact]
+    public async Task ToastContainer_DisposesOnlyItsOwnToastHandles()
+    {
+        var (_, module) = AddJsModule();
+        module.Setup(m => m.InvokeAsync<string>("showToast", It.IsAny<object[]>()))
+            .Returns(new ValueTask<string>("toast-1"));
+
+        var cut = RenderComponent<ToastContainer>(parameters => parameters
+            .Add(p => p.Id, "toast-container"));
+        await cut.Instance.ShowToast(new ToastConfig { Message = "Message" });
+
+        await cut.Instance.DisposeAsync();
+
+        module.Verify(m => m.InvokeAsync<Microsoft.JSInterop.Infrastructure.IJSVoidResult>(
+            "dispose", It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == "toast-container")), Times.Once);
+    }
+
+    [Fact]
+    public void ToastConfig_SerializesOfficialPropertyNamesAndEnumValues()
+    {
+        var json = JsonConvert.SerializeObject(new ToastConfig
         {
-            // Arrange
-            var attributes = new
-            {
-                role = "alert",
-                tabindex = "0",
-                id = "toast-container-1"
-            };
+            Title = "Saved",
+            Message = "Done",
+            Type = ToastType.Warning,
+            AutoClose = true,
+            AutoCloseDelay = 1000,
+            HideIcon = true
+        });
 
-            // Act
-            var cut = RenderComponent<Toast>(parameters => parameters
-                .AddUnmatched("role", attributes.role)
-                .AddUnmatched("tabindex", attributes.tabindex)
-                .AddUnmatched("id", attributes.id));
+        Assert.Contains("\"title\":\"Saved\"", json);
+        Assert.Contains("\"message\":\"Done\"", json);
+        Assert.Contains("\"type\":\"warning\"", json);
+        Assert.Contains("\"autoClose\":true", json);
+        Assert.DoesNotContain("preventAutoClose", json);
+        Assert.DoesNotContain("messageHtml", json);
+        Assert.DoesNotContain("position", json);
+    }
 
-            // Assert
-            cut.MarkupMatches($"<ix-toast-container role=\"{attributes.role}\" tabindex=\"{attributes.tabindex}\" id=\"{attributes.id}\"></ix-toast-container>");
-        }
-
-        [Fact]
-        public void StyleIsAppliedCorrectly()
-        {
-            // Arrange
-            var style = "position: fixed; top: 10px; right: 10px;";
-
-            // Act
-            var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Style, style));
-
-            // Assert
-            cut.MarkupMatches($"<ix-toast-container style=\"{style}\"></ix-toast-container>");
-        }
-
-        [Fact]
-        public void ClassIsAppliedCorrectly()
-        {
-            // Arrange
-            var className = "custom-toast-container";
-
-            // Act
-            var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Class, className));
-
-            // Assert
-            cut.MarkupMatches($"<ix-toast-container class=\"{className}\"></ix-toast-container>");
-        }
-
-        [Fact]
-        public async Task ShowToast_WithValidConfig_InvokesJSCorrectly()
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Message = "Test message",
-                Title = "Test title",
-                Type = "success",
-                Icon = "info",
-                IconColor = "#00FF00",
-                PreventAutoClose = true,
-                AutoCloseDelay = 3000
-            };
-
-            string expectedJson = JsonConvert.SerializeObject(toastConfig);
-
-            // Setup the expected JS call
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            // Act
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            // Assert
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task ShowToast_WithNullConfig_ThrowsArgumentNullException()
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-            var cut = RenderComponent<Toast>();
-
-            // Act & Assert
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-                await cut.InvokeAsync(() => cut.Instance.ShowToast(null)));
-        }
-
-        [Fact]
-        public async Task ShowToast_WithDefaultValues_UsesCorrectDefaults()
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Message = "Test message"
-            };
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => VerifyToastConfigDefaults(args[0].ToString(), "Test message"))))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            // Act
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            // Assert
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.IsAny<object[]>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task ShowToast_WhenJSRuntimeThrowsException_PropagatesException()
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig { Message = "Test message" };
-            var expectedException = new JSException("Test JS exception");
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.IsAny<object[]>()))
-                .ThrowsAsync(expectedException);
-
-            var cut = RenderComponent<Toast>();
-
-            // Act & Assert
-            var actualException = await Assert.ThrowsAsync<JSException>(async () =>
-                await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig)));
-
-            Assert.Same(expectedException, actualException);
-        }
-
-        [Theory]
-        [InlineData("info")]
-        [InlineData("success")]
-        [InlineData("warning")]
-        [InlineData("error")]
-        public async Task ShowToast_WithDifferentTypes_InvokesJSCorrectly(string toastType)
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Message = "Test message",
-                Type = toastType
-            };
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).Type == toastType)))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            // Act
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            // Assert
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).Type == toastType)),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task ShowToast_WithAction_PassesThroughInterop()
-        {
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Title = "Toast headline",
-                MessageHtml = "<div>Message from template</div>",
-                Action = "<ix-button variant=\"tertiary\" icon=\"undo\">Undo</ix-button>"
-            };
-
-            string expectedJson = JsonConvert.SerializeObject(toastConfig);
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(ToastPosition.BottomRight)]
-        [InlineData(ToastPosition.TopRight)]
-        public async Task ShowToast_WithPosition_PassesThroughInterop(ToastPosition position)
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Title = "Positioned Toast",
-                Message = "This toast has a position",
-                Position = position
-            };
-
-            string expectedJson = JsonConvert.SerializeObject(toastConfig);
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            // Act
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            // Assert
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).Position == position)),
-                Times.Once);
-        }
-
-        [Fact]
-        public void HideIconDefaultsToFalse()
-        {
-            // Arrange
-            var toastConfig = new ToastConfig();
-
-            // Assert
-            Assert.False(toastConfig.HideIcon);
-        }
-
-        [Fact]
-        public async Task ShowToast_WithHideIconTrue_PassesThroughInterop()
-        {
-            // Arrange
-            var jsRuntimeMock = new Mock<IJSRuntime>();
-            Services.AddSingleton(jsRuntimeMock.Object);
-
-            var toastConfig = new ToastConfig
-            {
-                Title = "Toast without icon",
-                Message = "This toast has no icon",
-                HideIcon = true
-            };
-
-            string expectedJson = JsonConvert.SerializeObject(toastConfig);
-
-            jsRuntimeMock
-                .Setup(js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => args.Length == 1 && args[0].ToString() == expectedJson)))
-                .ReturnsAsync(new ValueTask<object>());
-
-            var cut = RenderComponent<Toast>();
-
-            // Act
-            await cut.InvokeAsync(() => cut.Instance.ShowToast(toastConfig));
-
-            // Assert
-            jsRuntimeMock.Verify(
-                js => js.InvokeAsync<object>(
-                    It.Is<string>(s => s == "siemensIXInterop.showMessage"),
-                    It.Is<object[]>(args => JsonConvert.DeserializeObject<ToastConfig>(args[0].ToString()).HideIcon == true)),
-                Times.Once);
-        }
-
-        #region Helper Methods
-
-        private bool VerifyToastConfigDefaults(string json, string expectedMessage)
-        {
-            var config = JsonConvert.DeserializeObject<ToastConfig>(json);
-            if (config == null)
-                return false;
-
-            return config.Message == expectedMessage &&
-                   config.Type == "info" &&
-                   config.PreventAutoClose == true &&
-                   config.AutoCloseDelay == 5000;
-        }
-
-        #endregion
+    private (Mock<IJSRuntime> JsRuntime, Mock<IJSObjectReference> Module) AddJsModule()
+    {
+        var jsRuntime = new Mock<IJSRuntime>();
+        var module = new Mock<IJSObjectReference>();
+        jsRuntime.Setup(j => j.InvokeAsync<IJSObjectReference>("import", It.IsAny<object[]>()))
+            .Returns(new ValueTask<IJSObjectReference>(module.Object));
+        Services.AddSingleton(jsRuntime.Object);
+        return (jsRuntime, module);
     }
 }

--- a/SiemensIXBlazor/Components/Toast/Toast.razor
+++ b/SiemensIXBlazor/Components/Toast/Toast.razor
@@ -1,19 +1,35 @@
-﻿@* -----------------------------------------------------------------------
+@* -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 // SPDX-License-Identifier: MIT
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-//  -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 *@
 
-@using Microsoft.JSInterop;
+@using Microsoft.JSInterop
+@using SiemensIXBlazor.Enums
+@using SiemensIXBlazor.Helpers
 @inject IJSRuntime JSRuntime
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
 
-<ix-toast-container
-@attributes="UserAttributes"
-style="@Style"
-class="@Class"></ix-toast-container>
+<ix-toast @attributes="UserAttributes"
+          id="@Id"
+          class="@Class"
+          style="@Style"
+          type="@(EnumParser<ToastType>.EnumToString(Type))"
+          toast-title="@ToastTitle"
+          auto-close-delay="@AutoCloseDelay"
+          prevent-auto-close="@(PreventAutoClose ? "true" : null)"
+          icon="@Icon"
+          icon-color="@IconColor"
+          hide-icon="@(HideIcon ? "true" : null)"
+          aria-label-close-icon-button="@AriaLabelCloseIconButton">
+    @ChildContent
+    @if (ActionContent is not null)
+    {
+        <div slot="action">@ActionContent</div>
+    }
+</ix-toast>

--- a/SiemensIXBlazor/Components/Toast/Toast.razor.cs
+++ b/SiemensIXBlazor/Components/Toast/Toast.razor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -7,29 +7,93 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using Newtonsoft.Json;
-using SiemensIXBlazor.Objects;
+using SiemensIXBlazor.Enums;
 
 namespace SiemensIXBlazor.Components
 {
-    public partial class Toast
+    public partial class Toast : IAsyncDisposable
     {
-        public async Task ShowToast(ToastConfig config)
+        [Parameter, EditorRequired]
+        public string Id { get; set; } = string.Empty;
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+        [Parameter]
+        public RenderFragment? ActionContent { get; set; }
+        [Parameter]
+        public ToastType Type { get; set; } = ToastType.Info;
+        [Parameter]
+        public string? ToastTitle { get; set; }
+        [Parameter]
+        public int AutoCloseDelay { get; set; } = 5000;
+        [Parameter]
+        public bool PreventAutoClose { get; set; } = false;
+        [Parameter]
+        public string? Icon { get; set; }
+        [Parameter]
+        public string? IconColor { get; set; }
+        [Parameter]
+        public bool HideIcon { get; set; } = false;
+        [Parameter]
+        public string AriaLabelCloseIconButton { get; set; } = "Close toast";
+        [Parameter]
+        public EventCallback CloseToastEvent { get; set; }
+
+        private Lazy<Task<IJSObjectReference>>? _moduleTask;
+        private DotNetObjectReference<Toast>? _dotNetReference;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (config == null)
+            if (firstRender)
             {
-                throw new ArgumentNullException(nameof(config), "Toast configuration cannot be null");
+                _moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/toastInterop.js").AsTask());
+
+                _dotNetReference = DotNetObjectReference.Create(this);
+                await (await GetModule()).InvokeVoidAsync("listenCloseToast", _dotNetReference, Id);
+            }
+        }
+
+        public async Task PauseAsync()
+        {
+            await (await GetModule()).InvokeVoidAsync("pauseToast", Id);
+        }
+
+        public async Task ResumeAsync()
+        {
+            await (await GetModule()).InvokeVoidAsync("resumeToast", Id);
+        }
+
+        public async Task<bool> IsPausedAsync()
+        {
+            return await (await GetModule()).InvokeAsync<bool>("isToastPaused", Id);
+        }
+
+        [JSInvokable]
+        public async Task CloseToast()
+        {
+            await CloseToastEvent.InvokeAsync();
+        }
+
+        private Task<IJSObjectReference> GetModule()
+        {
+            _moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/toastInterop.js").AsTask());
+
+            return _moduleTask.Value;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_moduleTask is not null && _moduleTask.IsValueCreated)
+            {
+                var module = await _moduleTask.Value;
+                await module.InvokeVoidAsync("removeCloseToast", Id);
+                await module.DisposeAsync();
             }
 
-            try
-            {
-                await JSRuntime.InvokeAsync<object>("siemensIXInterop.showMessage", JsonConvert.SerializeObject(config));
-            }
-            catch (JSException jsException)
-            {
-                throw;
-            }
+            _dotNetReference?.Dispose();
         }
     }
 }

--- a/SiemensIXBlazor/Components/Toast/ToastContainer.razor
+++ b/SiemensIXBlazor/Components/Toast/ToastContainer.razor
@@ -1,0 +1,23 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+*@
+
+@using Microsoft.JSInterop
+@using SiemensIXBlazor.Enums
+@inject IJSRuntime JSRuntime
+@namespace SiemensIXBlazor.Components
+@inherits IXBaseComponent
+
+<ix-toast-container @attributes="UserAttributes"
+                    id="@Id"
+                    class="@Class"
+                    style="@Style"
+                    position="@(Position == ToastPosition.TopRight ? "top-right" : "bottom-right")">
+    @ChildContent
+</ix-toast-container>

--- a/SiemensIXBlazor/Components/Toast/ToastContainer.razor.cs
+++ b/SiemensIXBlazor/Components/Toast/ToastContainer.razor.cs
@@ -1,0 +1,82 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Newtonsoft.Json;
+using SiemensIXBlazor.Enums;
+using SiemensIXBlazor.Objects;
+using System.Text.Json;
+
+namespace SiemensIXBlazor.Components
+{
+    public partial class ToastContainer : IAsyncDisposable
+    {
+        [Parameter, EditorRequired]
+        public string Id { get; set; } = string.Empty;
+        [Parameter]
+        public ToastPosition Position { get; set; } = ToastPosition.BottomRight;
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+
+        private Lazy<Task<IJSObjectReference>>? _moduleTask;
+        private DotNetObjectReference<ToastContainer>? _dotNetReference;
+        private readonly Dictionary<string, ToastResult> _toastResults = [];
+
+        public async Task<ToastResult> ShowToast(ToastConfig config)
+        {
+            ArgumentNullException.ThrowIfNull(config);
+
+            var module = await GetModule();
+            _dotNetReference ??= DotNetObjectReference.Create(this);
+
+            var handle = await module.InvokeAsync<string>(
+                "showToast",
+                _dotNetReference,
+                Id,
+                JsonConvert.SerializeObject(config));
+
+            var result = new ToastResult(module, handle);
+            _toastResults[handle] = result;
+            return result;
+        }
+
+        [JSInvokable]
+        public Task ToastClosed(string handle, JsonElement? value)
+        {
+            if (_toastResults.Remove(handle, out var result))
+            {
+                result.NotifyClosed(value);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task<IJSObjectReference> GetModule()
+        {
+            _moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/toastInterop.js").AsTask());
+
+            return _moduleTask.Value;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_moduleTask is not null && _moduleTask.IsValueCreated)
+            {
+                var module = await _moduleTask.Value;
+                await module.InvokeVoidAsync("dispose", Id);
+                await module.DisposeAsync();
+            }
+
+            _toastResults.Clear();
+            _dotNetReference?.Dispose();
+        }
+    }
+}

--- a/SiemensIXBlazor/Enums/ToastType.cs
+++ b/SiemensIXBlazor/Enums/ToastType.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Runtime.Serialization;
+
+namespace SiemensIXBlazor.Enums
+{
+    public enum ToastType
+    {
+        [EnumMember(Value = "info")]
+        Info,
+
+        [EnumMember(Value = "success")]
+        Success,
+
+        [EnumMember(Value = "warning")]
+        Warning,
+
+        [EnumMember(Value = "error")]
+        Error
+    }
+}

--- a/SiemensIXBlazor/Objects/ToastConfig.cs
+++ b/SiemensIXBlazor/Objects/ToastConfig.cs
@@ -16,36 +16,46 @@ namespace SiemensIXBlazor.Objects
 	public class ToastConfig
 	{
 		/// <summary>
-		/// Sets the HTML content for the toast action area.
-		/// This property accepts an HTML string containing interactive elements such as <c>&lt;ix-button&gt;</c>.
+		/// Toast title.
 		/// </summary>
-		/// <remarks>
-		/// The HTML string is rendered directly within the toast's action container.
-		/// Ensure content is properly escaped to prevent XSS vulnerabilities.
-		/// </remarks>
-		[JsonProperty("action")]
-		public string? Action { get; set; }
-        [JsonProperty("preventAutoClose")]
-        public bool PreventAutoClose { get; set; } = false;
-        [JsonProperty("autoCloseDelay")]
-		public int AutoCloseDelay { get; set; } = 5000;
-		[JsonProperty("hideIcon")]
-		public bool HideIcon { get; set; } = false;
-		[JsonProperty("icon")]
-		public string? Icon { get; set; }
-		[JsonProperty("iconColor")]
-		public string? IconColor { get; set; }
-		[JsonProperty("message")]
-		public string? Message { get; set; }
-		[JsonProperty("messageHtml")]
-		public string? MessageHtml { get; set; }
-		[JsonProperty("position")]
-		[JsonConverter(typeof(StringEnumConverter))]
-		public ToastPosition? Position { get; set; }
 		[JsonProperty("title")]
 		public string? Title { get; set; }
+
+		/// <summary>
+		/// Toast message text.
+		/// </summary>
+		[JsonProperty("message")]
+		public string? Message { get; set; }
+
+		/// <summary>
+		/// HTML content for the action area.
+		/// </summary>
+		[JsonProperty("action")]
+		public string? Action { get; set; }
+
+		/// <summary>
+		/// Toast type. The official default is info when omitted.
+		/// </summary>
 		[JsonProperty("type")]
-		public string Type { get; set; } = "info";
+		[JsonConverter(typeof(StringEnumConverter))]
+		public ToastType? Type { get; set; }
+
+		/// <summary>
+		/// Whether the toast closes automatically.
+		/// </summary>
+		[JsonProperty("autoClose")]
+		public bool? AutoClose { get; set; }
+
+		[JsonProperty("autoCloseDelay")]
+		public int? AutoCloseDelay { get; set; }
+
+		[JsonProperty("icon")]
+		public string? Icon { get; set; }
+
+		[JsonProperty("iconColor")]
+		public string? IconColor { get; set; }
+
+		[JsonProperty("hideIcon")]
+		public bool? HideIcon { get; set; }
 	}
 }
-

--- a/SiemensIXBlazor/Objects/ToastResult.cs
+++ b/SiemensIXBlazor/Objects/ToastResult.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.JSInterop;
+using System.Text.Json;
+
+namespace SiemensIXBlazor.Objects
+{
+    public sealed class ToastResult
+    {
+        private readonly IJSObjectReference _interop;
+        private readonly string _handle;
+
+        internal ToastResult(IJSObjectReference interop, string handle)
+        {
+            _interop = interop;
+            _handle = handle;
+        }
+
+        public event EventHandler<JsonElement?>? OnClose;
+
+        public ValueTask PauseAsync() => _interop.InvokeVoidAsync("pause", _handle);
+
+        public ValueTask ResumeAsync() => _interop.InvokeVoidAsync("resume", _handle);
+
+        public ValueTask<bool> IsPausedAsync() => _interop.InvokeAsync<bool>("isPaused", _handle);
+
+        public ValueTask CloseAsync(object? result = null) => _interop.InvokeVoidAsync("close", _handle, result);
+
+        internal void NotifyClosed(JsonElement? result)
+        {
+            OnClose?.Invoke(this, result);
+        }
+    }
+}

--- a/SiemensIXBlazor/SiemensIXBlazor_NpmJS/src/index.js
+++ b/SiemensIXBlazor/SiemensIXBlazor_NpmJS/src/index.js
@@ -1,5 +1,4 @@
 ﻿import { defineCustomElements } from "@siemens/ix/loader";
-import { toast, setToastPosition } from "@siemens/ix";
 import "@siemens/ix-echarts";
 import { registerTheme } from "@siemens/ix-echarts";
 import * as echarts from "echarts";
@@ -46,33 +45,6 @@ window.siemensIXInterop = {
                 console.error(`[siemensIXInterop.modal.toggle] Element with id '${id}' not found.`);
             }
         },
-    },
-
-    showMessage(config) {
-        try {
-            const toastConfig = JSON.parse(config);
-            if (toastConfig.messageHtml) {
-                const msgEl = document.createElement('div');
-                msgEl.innerHTML = toastConfig.messageHtml;
-                toastConfig.message = msgEl;
-            }
-
-            if (toastConfig.action) {
-                const actionEl = document.createElement('div');
-                actionEl.innerHTML = toastConfig.action;
-                actionEl.slot = 'action';
-                toastConfig.action = actionEl;
-            }
-
-            if (toastConfig.position) {
-                setToastPosition(toastConfig.position);
-                delete toastConfig.position;
-            }
-
-            toast(toastConfig);
-        } catch (error) {
-            console.error("Failed to display toast message:", error);
-        }
     },
 
     initializeChart(id, options) {

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/toastInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/toastInterop.js
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+const toastHandles = new Map();
+const closeToastListeners = new Map();
+let nextHandle = 0;
+
+function getElement(id) {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Element with ID ${id} not found`);
+  }
+
+  return element;
+}
+
+export function listenCloseToast(dotNetReference, id) {
+  const element = getElement(id);
+  removeCloseToast(id);
+
+  const listener = () => dotNetReference.invokeMethodAsync("CloseToast");
+  element.addEventListener("closeToast", listener);
+  closeToastListeners.set(id, { element, listener });
+}
+
+export function removeCloseToast(id) {
+  const entry = closeToastListeners.get(id);
+  if (!entry) {
+    return;
+  }
+
+  entry.element.removeEventListener("closeToast", entry.listener);
+  closeToastListeners.delete(id);
+}
+
+export function pauseToast(id) {
+  return getElement(id).pause();
+}
+
+export function resumeToast(id) {
+  return getElement(id).resume();
+}
+
+export function isToastPaused(id) {
+  return getElement(id).isPaused();
+}
+
+export async function showToast(dotNetReference, containerId, configJson) {
+  const container = getElement(containerId);
+  const config = JSON.parse(configJson);
+
+  if (typeof config.action === "string") {
+    const action = document.createElement("div");
+    action.innerHTML = config.action;
+    config.action = action;
+  }
+
+  const result = await container.showToast(config);
+  const handle = String(++nextHandle);
+  result.onClose.on((value) => {
+    toastHandles.delete(handle);
+    dotNetReference.invokeMethodAsync("ToastClosed", handle, value ?? null);
+  });
+  toastHandles.set(handle, { result, containerId });
+  return handle;
+}
+
+function getResult(handle) {
+  const entry = toastHandles.get(handle);
+  if (!entry) {
+    throw new Error(`Toast handle ${handle} not found`);
+  }
+
+  return entry.result;
+}
+
+export function pause(handle) {
+  return getResult(handle).pause();
+}
+
+export function resume(handle) {
+  return getResult(handle).resume();
+}
+
+export function isPaused(handle) {
+  return getResult(handle).isPaused();
+}
+
+export function close(handle, result) {
+  return getResult(handle).close(result);
+}
+
+export function dispose(containerId) {
+  for (const [handle, entry] of toastHandles) {
+    if (entry.containerId === containerId) {
+      toastHandles.delete(handle);
+    }
+  }
+  for (const id of closeToastListeners.keys()) {
+    removeCloseToast(id);
+  }
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

Toast support only exposed the older global helper and did not provide complete wrappers for `ix-toast`, `ix-toast-container`, or the returned toast lifecycle handle.

GitHub Issue Number: #261

## 🆕 What is the new behavior?

- Add complete Toast and ToastContainer public APIs with official properties, slots, and positioning.
- Support toast lifecycle controls, close events, typed configuration, and updated tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)