### PR TITLE
feat(form-fields): complete input and custom field wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ public partial class Index
 - [Group](#group)
 - [HTML Table](#html-table)
 - [Input](#input)
+- [Number Input](#number-input)
+- [Custom Field](#custom-field)
+- [Field Label](#field-label)
+- [Helper Text](#helper-text)
 - [Key Value List](#key-value-list) **(since v0.3.3)**
 - [Key Value](#key-value) **(since v0.3.3)**
 - [KPI](#kpi)
@@ -979,14 +983,67 @@ private void DrawerButtonClicked()
 ## Input
 
 ```razor
-<form class="needs-validation m-2">
-  <input
-    class="form-control"
-    defaultValue="Some example text"
-    placeholder="Enter text here"
-    type="text"
-  />
-</form>
+<Input Id="input-example"
+       Type="InputType.Email"
+       Label="Email"
+       Placeholder="name@example.com"
+       TextAlignment="TextAlignment.Start"
+       SuppressSubmitOnEnter="true"
+       ValueChangeEvent="OnInputValueChanged"
+       IxChangeEvent="OnInputChanged" />
+```
+
+## Number Input
+
+```razor
+<NumberInput Id="number-input-example"
+             Label="Quantity"
+             Value="10"
+             Min="0"
+             Max="100"
+             Step="1"
+             AllowEmptyValueChange="true"
+             ValueChangeEvent="OnNumberChanged"
+             IxChangeEvent="OnNumberCommitted" />
+```
+
+## Text Area
+
+```razor
+<TextArea Id="text-area-example"
+          Label="Description"
+          TextareaRows="4"
+          ResizeBehavior="TextAreaResizeBehavior.Vertical"
+          ValueChangeEvent="OnTextChanged"
+          IxChangeEvent="OnTextCommitted" />
+```
+
+## Custom Field
+
+```razor
+<CustomField Id="custom-field-example"
+             Label="Custom control"
+             HelperText="Choose an option">
+  <select aria-label="Custom control">
+    <option>Option one</option>
+  </select>
+</CustomField>
+```
+
+## Field Label
+
+```razor
+<FieldLabel HtmlFor="custom-control" Required="true">
+  Custom control
+</FieldLabel>
+```
+
+## Helper Text
+
+```razor
+<HelperText HtmlFor="custom-control"
+            HelperText="Choose an option"
+            InvalidText="This value is required" />
 ```
 
 ## Key Value List

--- a/SiemensIXBlazor.Tests/FormFieldTests.cs
+++ b/SiemensIXBlazor.Tests/FormFieldTests.cs
@@ -1,0 +1,125 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using System.Text.Json;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Components.CustomField;
+using SiemensIXBlazor.Components.FieldLabel;
+using SiemensIXBlazor.Components.HelperText;
+using SiemensIXBlazor.Components.Input;
+using SiemensIXBlazor.Components.NumberInput;
+using SiemensIXBlazor.Components.TextArea;
+using SiemensIXBlazor.Enums.Input;
+using SiemensIXBlazor.Enums.TextArea;
+using SiemensIXBlazor.Objects;
+
+namespace SiemensIXBlazor.Tests;
+
+public class FormFieldTests : TestContextBase
+{
+    [Fact]
+    public void InputRendersOfficialDefaultsAndProperties()
+    {
+        var cut = RenderComponent<Input>(parameters => parameters
+            .Add(p => p.Id, "input")
+            .Add(p => p.Type, InputType.Email)
+            .Add(p => p.SuppressSubmitOnEnter, true)
+            .Add(p => p.TextAlignment, TextAlignment.End));
+
+        var element = cut.Find("ix-input");
+        Assert.Equal("email", element.GetAttribute("type"));
+        Assert.Equal("true", element.GetAttribute("suppress-submit-on-enter"));
+        Assert.Equal("end", element.GetAttribute("text-alignment"));
+    }
+
+    [Fact]
+    public void NumberInputSupportsNullableValueAndOfficialProperties()
+    {
+        var cut = RenderComponent<NumberInput>(parameters => parameters
+            .Add(p => p.Id, "number")
+            .Add(p => p.AllowEmptyValueChange, true)
+            .Add(p => p.Value, null)
+            .Add(p => p.TextAlignment, TextAlignment.Start));
+
+        var element = cut.Find("ix-number-input");
+        Assert.Equal("true", element.GetAttribute("allow-empty-value-change"));
+        Assert.Equal("start", element.GetAttribute("text-alignment"));
+        Assert.Null(element.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task NumberInputEmitsNullableValue()
+    {
+        double? received = 1;
+        var cut = RenderComponent<NumberInput>(parameters => parameters
+            .Add(p => p.Id, "number")
+            .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<double?>(this, value => received = value)));
+
+        await cut.Instance.ValueChange(JsonDocument.Parse("null").RootElement);
+
+        Assert.Null(received);
+        Assert.Null(cut.Instance.Value);
+    }
+
+    [Fact]
+    public void TextAreaUsesTypedResizeBehavior()
+    {
+        var cut = RenderComponent<TextArea>(parameters => parameters
+            .Add(p => p.Id, "textarea")
+            .Add(p => p.ResizeBehavior, TextAreaResizeBehavior.Vertical));
+
+        Assert.Equal("vertical", cut.Find("ix-textarea").GetAttribute("resize-behavior"));
+    }
+
+    [Fact]
+    public async Task InputValidityStateUsesTypedCallback()
+    {
+        ValidityState? received = null;
+        var cut = RenderComponent<Input>(parameters => parameters
+            .Add(p => p.Id, "input")
+            .Add(p => p.ValidityStateChangeEvent,
+                EventCallback.Factory.Create<ValidityState>(this, value => received = value)));
+
+        await cut.Instance.ValidityStateChange(new ValidityState { Valid = true });
+
+        Assert.NotNull(received);
+        Assert.True(received!.Valid);
+    }
+
+    [Fact]
+    public void CustomFieldOnlyRendersItsDefaultSlot()
+    {
+        var cut = RenderComponent<CustomField>(parameters => parameters
+            .Add(p => p.Id, "custom")
+            .AddChildContent("control"));
+
+        Assert.Contains("control", cut.Find("ix-custom-field").InnerHtml);
+        Assert.DoesNotContain("file-upload", cut.Markup);
+    }
+
+    [Fact]
+    public void FieldLabelAndHelperTextMapTheirPublicAttributes()
+    {
+        var label = RenderComponent<FieldLabel>(parameters => parameters
+            .Add(p => p.HtmlFor, "input")
+            .Add(p => p.Required, true)
+            .AddChildContent("Label"));
+        var helper = RenderComponent<HelperText>(parameters => parameters
+            .Add(p => p.HtmlFor, "input")
+            .Add(p => p.HelperText, "Help")
+            .Add(p => p.InvalidText, "Error"));
+
+        Assert.Equal("input", label.Find("ix-field-label").GetAttribute("html-for"));
+        Assert.Equal("true", label.Find("ix-field-label").GetAttribute("required"));
+        Assert.Equal("input", helper.Find("ix-helper-text").GetAttribute("html-for"));
+        Assert.Equal("Help", helper.Find("ix-helper-text").GetAttribute("helper-text"));
+        Assert.Equal("Error", helper.Find("ix-helper-text").GetAttribute("invalid-text"));
+    }
+}

--- a/SiemensIXBlazor.Tests/InputTest.cs
+++ b/SiemensIXBlazor.Tests/InputTest.cs
@@ -30,32 +30,32 @@ public class InputTest : TestContextBase
     }
 
     [Fact]
-    public void ChangeEventWorks()
+    public async Task IxChangeEventWorks()
     {
         // Arrange
         var received = string.Empty;
         var cut = RenderComponent<Input>(parameters => parameters
             .Add(p => p.Id, "test-input")
-            .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
+            .Add(p => p.IxChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 
         // Act
-        cut.Instance.Change(JsonDocument.Parse("\"hello\"").RootElement);
+        await cut.Instance.IxChange(JsonDocument.Parse("\"hello\"").RootElement);
 
         // Assert
         Assert.Equal("hello", received);
     }
 
     [Fact]
-    public void ChangeEventReceivesEmptyStringWhenValueIsNull()
+    public async Task IxChangeEventReceivesEmptyStringWhenValueIsNull()
     {
         // Arrange
         var received = "initial";
         var cut = RenderComponent<Input>(parameters => parameters
             .Add(p => p.Id, "test-input")
-            .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
+            .Add(p => p.IxChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 
         // Act
-        cut.Instance.Change(JsonDocument.Parse("null").RootElement);
+        await cut.Instance.IxChange(JsonDocument.Parse("null").RootElement);
 
         // Assert
         Assert.Equal(string.Empty, received);

--- a/SiemensIXBlazor/Components/CustomField/CustomField.razor
+++ b/SiemensIXBlazor/Components/CustomField/CustomField.razor
@@ -1,7 +1,15 @@
-﻿@using Microsoft.JSInterop;
-@using SiemensIXBlazor.Components
+﻿@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
 @inherits IXBaseComponent
-@inject IJSRuntime JSRuntime
+
 
 <ix-custom-field @attributes="UserAttributes"
                  class="@Class"
@@ -11,27 +19,11 @@
                  info-text="@InfoText"
                  invalid-text="@InvalidText"
                  label="@Label"
-                 required="@Required"
+                 required="@(Required ? "true" : null)"
                  show-text-as-tooltip="@ShowTextAsTooltip"
                  valid-text="@ValidText"
                  warning-text="@WarningText">
 
-    @if (IsFileUpload)
-    {
-        <ix-input @ref="inputRef" value="@FileDisplayText" readonly></ix-input>
-        <ix-icon-button @ref="buttonRef"
-                        icon="open-file"
-                        variant="primary"
-                        outline="true">
-        </ix-icon-button>
-        <input @ref="fileRef"
-               id="@($"{Id}-file-upload")"
-               type="file"
-               style="display: none" />
-    }
-    else
-    {
-        @ChildContent
-    }
+    @ChildContent
 
 </ix-custom-field>

--- a/SiemensIXBlazor/Components/FieldLabel/FieldLabel.razor
+++ b/SiemensIXBlazor/Components/FieldLabel/FieldLabel.razor
@@ -1,0 +1,21 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
+@inherits IXBaseComponent
+
+<ix-field-label @attributes="UserAttributes"
+                id="@Id"
+                class="@Class"
+                style="@Style"
+                html-for="@HtmlFor"
+                is-invalid="@(IsInvalid ? "true" : null)"
+                required="@(Required == true ? "true" : null)">
+    @ChildContent
+</ix-field-label>

--- a/SiemensIXBlazor/Components/FieldLabel/FieldLabel.razor.cs
+++ b/SiemensIXBlazor/Components/FieldLabel/FieldLabel.razor.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace SiemensIXBlazor.Components.FieldLabel
+{
+    public partial class FieldLabel
+    {
+        [Parameter]
+        public string? Id { get; set; }
+
+        [Parameter]
+        public string? HtmlFor { get; set; }
+
+        [Parameter]
+        public bool? Required { get; set; }
+
+        [Parameter]
+        public bool IsInvalid { get; set; } = false;
+
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+    }
+}

--- a/SiemensIXBlazor/Components/HelperText/HelperText.razor
+++ b/SiemensIXBlazor/Components/HelperText/HelperText.razor
@@ -1,0 +1,23 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
+@inherits HelperTextBase
+
+<ix-helper-text @attributes="UserAttributes"
+                id="@Id"
+                class="@Class"
+                style="@Style"
+                html-for="@HtmlFor"
+                helper-text="@HelperText"
+                info-text="@InfoText"
+                invalid-text="@InvalidText"
+                valid-text="@ValidText"
+                warning-text="@WarningText">
+</ix-helper-text>

--- a/SiemensIXBlazor/Components/HelperText/HelperTextBase.cs
+++ b/SiemensIXBlazor/Components/HelperText/HelperTextBase.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2026 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -8,16 +8,17 @@
 //  -----------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Components;
 
-namespace SiemensIXBlazor.Components.CustomField
+namespace SiemensIXBlazor.Components.HelperText
 {
-    public partial class CustomField
+    public abstract class HelperTextBase : IXBaseComponent
     {
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
+        [Parameter]
+        public string? Id { get; set; }
 
         [Parameter]
-        public RenderFragment? ChildContent { get; set; }
+        public string? HtmlFor { get; set; }
 
         [Parameter]
         public string? HelperText { get; set; }
@@ -29,19 +30,9 @@ namespace SiemensIXBlazor.Components.CustomField
         public string? InvalidText { get; set; }
 
         [Parameter]
-        public string? Label { get; set; }
-
-        [Parameter]
-        public bool Required { get; set; } = false;
-
-        [Parameter]
-        public bool? ShowTextAsTooltip { get; set; }
-
-        [Parameter]
         public string? ValidText { get; set; }
 
         [Parameter]
         public string? WarningText { get; set; }
-
     }
 }

--- a/SiemensIXBlazor/Components/Input/Input.razor
+++ b/SiemensIXBlazor/Components/Input/Input.razor
@@ -1,5 +1,16 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
 @using Microsoft.JSInterop;
-@using SiemensIXBlazor.Components
+@using SiemensIXBlazor.Enums.Input
+@using SiemensIXBlazor.Helpers
 @inherits IXBaseComponent
 @inject IJSRuntime JSRuntime
 
@@ -7,11 +18,11 @@
           class="@Class"
           style="@Style"
           id="@Id"
-          type="@Type"   
+          type="@(EnumParser<InputType>.EnumToString(Type))"
           placeholder="@Placeholder"
           value="@Value"
-          disabled="@Disabled"
-          readonly="@Readonly"
+          disabled="@(Disabled ? "true" : null)"
+          readonly="@(Readonly ? "true" : null)"
           label="@Label"
           helper-text="@HelperText"
           info-text="@InfoText"
@@ -24,7 +35,9 @@
           show-text-as-tooltip="@ShowTextAsTooltip"
           pattern="@Pattern"
           name="@Name"
-          required="@Required">
+          required="@(Required ? "true" : null)"
+          suppress-submit-on-enter="@(SuppressSubmitOnEnter ? "true" : null)"
+          text-alignment="@(EnumParser<TextAlignment>.EnumToString(TextAlignment))">
     @if (StartSlot != null)
     {
         <div slot="start">

--- a/SiemensIXBlazor/Components/Input/Input.razor.cs
+++ b/SiemensIXBlazor/Components/Input/Input.razor.cs
@@ -1,6 +1,17 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using SiemensIXBlazor.Enums.Input;
 using SiemensIXBlazor.Interops;
+using SiemensIXBlazor.Objects;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Components.Input
@@ -30,7 +41,7 @@ namespace SiemensIXBlazor.Components.Input
         public bool Readonly { get; set; } = false;
 
         [Parameter]
-        public string Type { get; set; } = "text";
+        public InputType Type { get; set; } = InputType.Text;
 
         [Parameter]
         public string? Label { get; set; }
@@ -66,10 +77,16 @@ namespace SiemensIXBlazor.Components.Input
         public string? Name { get; set; }
 
         [Parameter]
-        public bool ShowTextAsTooltip { get; set; } = false;
+        public bool? ShowTextAsTooltip { get; set; }
 
         [Parameter]
         public string? Pattern { get; set; }
+
+        [Parameter]
+        public bool SuppressSubmitOnEnter { get; set; } = false;
+
+        [Parameter]
+        public TextAlignment TextAlignment { get; set; } = TextAlignment.Start;
 
         [Parameter]
         public RenderFragment? StartSlot { get; set; }
@@ -81,13 +98,25 @@ namespace SiemensIXBlazor.Components.Input
         public EventCallback<string> ValueChangeEvent { get; set; }
 
         [Parameter]
-        public EventCallback<string> ChangeEvent { get; set; }
+        public EventCallback<string> IxChangeEvent { get; set; }
 
         [Parameter]
         public EventCallback IxBlurEvent { get; set; }
 
         [Parameter]
-        public EventCallback<JsonElement> ValidityStateChangeEvent { get; set; }
+        public EventCallback<ValidityState> ValidityStateChangeEvent { get; set; }
+
+        public async Task FocusInputAsync()
+        {
+            _interop ??= new(JSRuntime);
+            await _interop.InvokeVoidMethod(Id, "focusInput");
+        }
+
+        public async Task<ValidityState> GetValidityStateAsync()
+        {
+            _interop ??= new(JSRuntime);
+            return await _interop.InvokeMethod<ValidityState>(Id, "getValidityState");
+        }
 
         protected override void OnAfterRender(bool firstRender)
         {
@@ -98,7 +127,7 @@ namespace SiemensIXBlazor.Components.Input
                 Task.Run(async () =>
                 {
                     await _interop.AddEventListener(this, Id, "valueChange", "ValueChange");
-                    await _interop.AddEventListener(this, Id, "change", "Change");
+                    await _interop.AddEventListener(this, Id, "ixChange", "IxChange");
                     await _interop.AddEventListener(this, Id, "ixBlur", "IxBlur");
                     await _interop.AddEventListener(this, Id, "validityStateChange", "ValidityStateChange");
                 });
@@ -111,23 +140,23 @@ namespace SiemensIXBlazor.Components.Input
             string newValue = valueState.GetString() ?? "";
             _value = newValue;
             await ValueChangeEvent.InvokeAsync(newValue);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         [JSInvokable]
-        public async void Change(JsonElement valueState)
+        public async Task IxChange(JsonElement valueState)
         {
-            await ChangeEvent.InvokeAsync(valueState.GetString() ?? "");
+            await IxChangeEvent.InvokeAsync(valueState.GetString() ?? "");
         }
 
         [JSInvokable]
-        public async void IxBlur()
+        public async Task IxBlur()
         {
             await IxBlurEvent.InvokeAsync();
         }
 
         [JSInvokable]
-        public async void ValidityStateChange(JsonElement validityState)
+        public async Task ValidityStateChange(ValidityState validityState)
         {
             await ValidityStateChangeEvent.InvokeAsync(validityState);
         }

--- a/SiemensIXBlazor/Components/NumberInput/NumberInput.razor
+++ b/SiemensIXBlazor/Components/NumberInput/NumberInput.razor
@@ -1,11 +1,25 @@
-﻿@using Microsoft.JSInterop;
-@using SiemensIXBlazor.Components
+﻿@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
+@using Microsoft.JSInterop;
+@using SiemensIXBlazor.Enums.Input
+@using SiemensIXBlazor.Helpers
 @inherits IXBaseComponent
 @inject IJSRuntime JSRuntime
 
-<ix-number-input id="@Id"
+<ix-number-input @attributes="UserAttributes"
+                 class="@Class"
+                 style="@Style"
+                 id="@Id"
                  allowed-characters-pattern="@AllowedCharactersPattern"
-                 disabled="@Disabled"
+                 disabled="@(Disabled ? "true" : null)"
                  helper-text="@HelperText"
                  info-text="@InfoText"
                  invalid-text="@InvalidText"
@@ -15,15 +29,18 @@
                  name="@Name"
                  pattern="@Pattern"
                  placeholder="@Placeholder"
-                 readonly="@Readonly"
-                 required="@Required"
+                 readonly="@(Readonly ? "true" : null)"
+                 required="@(Required ? "true" : null)"
                  show-stepper-buttons="@ShowStepperButtons"
                  show-text-as-tooltip="@ShowTextAsTooltip"
                  step="@Step"
+                 allow-empty-value-change="@(AllowEmptyValueChange ? "true" : null)"
+                 suppress-submit-on-enter="@(SuppressSubmitOnEnter ? "true" : null)"
+                 text-alignment="@(EnumParser<TextAlignment>.EnumToString(TextAlignment))"
                  valid-text="@ValidText"
                  value="@Value"
                  warning-text="@WarningText"
-                 class="@CssClass">
+                 >
     @if (StartSlot != null)
     {
         <div slot="start">

--- a/SiemensIXBlazor/Components/NumberInput/NumberInput.razor.cs
+++ b/SiemensIXBlazor/Components/NumberInput/NumberInput.razor.cs
@@ -1,7 +1,17 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using Newtonsoft.Json.Linq;
+using SiemensIXBlazor.Enums.Input;
 using SiemensIXBlazor.Interops;
+using SiemensIXBlazor.Objects;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Components.NumberInput
@@ -62,16 +72,22 @@ namespace SiemensIXBlazor.Components.NumberInput
         public object? Step { get; set; }
 
         [Parameter]
+        public bool SuppressSubmitOnEnter { get; set; } = false;
+
+        [Parameter]
+        public TextAlignment TextAlignment { get; set; } = TextAlignment.End;
+
+        [Parameter]
+        public bool AllowEmptyValueChange { get; set; } = false;
+
+        [Parameter]
         public string? ValidText { get; set; }
 
         [Parameter]
-        public double Value { get; set; } = 0;
+        public double? Value { get; set; } = 0;
 
         [Parameter]
         public string? WarningText { get; set; }
-
-        [Parameter]
-        public string? CssClass { get; set; }
 
         [Parameter]
         public RenderFragment? StartSlot { get; set; }
@@ -83,10 +99,19 @@ namespace SiemensIXBlazor.Components.NumberInput
         public EventCallback IxBlurEvent { get; set; }
 
         [Parameter]
-        public EventCallback<object> ValidityStateChangeEvent { get; set; }
+        public EventCallback<ValidityState> ValidityStateChangeEvent { get; set; }
 
         [Parameter]
-        public EventCallback<double> ValueChangeEvent { get; set; }
+        public EventCallback<double?> ValueChangeEvent { get; set; }
+
+        [Parameter]
+        public EventCallback<double?> IxChangeEvent { get; set; }
+
+        public async Task FocusInputAsync()
+        {
+            _interop ??= new(JSRuntime);
+            await _interop.InvokeVoidMethod(Id, "focusInput");
+        }
 
         protected override void OnAfterRender(bool firstRender)
         {
@@ -99,29 +124,51 @@ namespace SiemensIXBlazor.Components.NumberInput
                     await _interop.AddEventListener(this, Id, "ixBlur", "IxBlur");
                     await _interop.AddEventListener(this, Id, "validityStateChange", "ValidityStateChange");
                     await _interop.AddEventListener(this, Id, "valueChange", "ValueChange");
+                    await _interop.AddEventListener(this, Id, "ixChange", "IxChange");
                 });
             }
         }
 
         [JSInvokable]
-        public async void IxBlur()
+        public async Task IxBlur()
         {
             await IxBlurEvent.InvokeAsync();
         }
 
         [JSInvokable]
-        public async void ValidityStateChange(JsonElement validityState)
+        public async Task ValidityStateChange(ValidityState validityState)
         {
             await ValidityStateChangeEvent.InvokeAsync(validityState);
         }
 
         [JSInvokable]
-        public async void ValueChange(JsonElement valueState)
+        public async Task ValueChange(JsonElement valueState)
         {
-            double newValue = valueState.GetDouble();
+            double? newValue = valueState.ValueKind switch
+            {
+                JsonValueKind.Null or JsonValueKind.Undefined => null,
+                JsonValueKind.Number => valueState.GetDouble(),
+                JsonValueKind.String when double.TryParse(valueState.GetString(), out var value) => value,
+                _ => null
+            };
+
             Value = newValue;
             await ValueChangeEvent.InvokeAsync(newValue);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
+        }
+
+        [JSInvokable]
+        public async Task IxChange(JsonElement valueState)
+        {
+            double? newValue = valueState.ValueKind switch
+            {
+                JsonValueKind.Null or JsonValueKind.Undefined => null,
+                JsonValueKind.Number => valueState.GetDouble(),
+                JsonValueKind.String when double.TryParse(valueState.GetString(), out var value) => value,
+                _ => null
+            };
+
+            await IxChangeEvent.InvokeAsync(newValue);
         }
     }
 }

--- a/SiemensIXBlazor/Components/TextArea/TextArea.razor
+++ b/SiemensIXBlazor/Components/TextArea/TextArea.razor
@@ -1,13 +1,27 @@
-﻿@using Microsoft.JSInterop;
-@using SiemensIXBlazor.Components
+﻿@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+*@
+
+@using Microsoft.JSInterop;
+@using SiemensIXBlazor.Enums.TextArea
+@using SiemensIXBlazor.Helpers
 @inherits IXBaseComponent
 @inject IJSRuntime JSRuntime
 
-<ix-textarea id="@Id"
+<ix-textarea @attributes="UserAttributes"
+             class="@Class"
+             style="@Style"
+             id="@Id"
              value="@Value"
-             disabled="@Disabled"
-             readonly="@Readonly"
-             required="@Required"
+             disabled="@(Disabled ? "true" : null)"
+             readonly="@(Readonly ? "true" : null)"
+             required="@(Required ? "true" : null)"
              max-length="@MaxLength"
              min-length="@MinLength"
              name="@Name"
@@ -17,12 +31,12 @@
              textarea-cols="@TextareaCols"
              textarea-height="@TextareaHeight"
              textarea-width="@TextareaWidth"
-             resize-behavior="@ResizeBehavior"
+             resize-behavior="@(EnumParser<TextAreaResizeBehavior>.EnumToString(ResizeBehavior))"
              helper-text="@HelperText"
              info-text="@InfoText"
              warning-text="@WarningText"
              valid-text="@ValidText"
              invalid-text="@InvalidText"
              show-text-as-tooltip="@ShowTextAsTooltip"
-             class="@CssClass">
+             >
 </ix-textarea>

--- a/SiemensIXBlazor/Components/TextArea/TextArea.razor.cs
+++ b/SiemensIXBlazor/Components/TextArea/TextArea.razor.cs
@@ -1,6 +1,17 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using SiemensIXBlazor.Enums.TextArea;
 using SiemensIXBlazor.Interops;
+using SiemensIXBlazor.Objects;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Components.TextArea
@@ -52,9 +63,6 @@ namespace SiemensIXBlazor.Components.TextArea
         public string? WarningText { get; set; }
 
         [Parameter]
-        public string? CssClass { get; set; }
-
-        [Parameter]
         public int? MaxLength { get; set; }
 
         [Parameter]
@@ -73,16 +81,25 @@ namespace SiemensIXBlazor.Components.TextArea
         public string? TextareaWidth { get; set; }
 
         [Parameter]
-        public string ResizeBehavior { get; set; } = "both";
+        public TextAreaResizeBehavior ResizeBehavior { get; set; } = TextAreaResizeBehavior.Both;
 
         [Parameter]
         public EventCallback IxBlurEvent { get; set; }
 
         [Parameter]
-        public EventCallback<JsonElement> ValidityStateChangeEvent { get; set; }
+        public EventCallback<ValidityState> ValidityStateChangeEvent { get; set; }
 
         [Parameter]
         public EventCallback<string> ValueChangeEvent { get; set; }
+
+        [Parameter]
+        public EventCallback<string> IxChangeEvent { get; set; }
+
+        public async Task FocusInputAsync()
+        {
+            _interop ??= new(JSRuntime);
+            await _interop.InvokeVoidMethod(Id, "focusInput");
+        }
 
         protected override void OnAfterRender(bool firstRender)
         {
@@ -93,6 +110,7 @@ namespace SiemensIXBlazor.Components.TextArea
                 Task.Run(async () =>
                 {
                     await _interop.AddEventListener(this, Id, "valueChange", "ValueChange");
+                    await _interop.AddEventListener(this, Id, "ixChange", "IxChange");
                     await _interop.AddEventListener(this, Id, "ixBlur", "IxBlur");
                     await _interop.AddEventListener(this, Id, "validityStateChange", "ValidityStateChange");
                 });
@@ -100,24 +118,30 @@ namespace SiemensIXBlazor.Components.TextArea
         }
 
         [JSInvokable]
-        public async void ValueChange(JsonElement valueState)
+        public async Task ValueChange(JsonElement valueState)
         {
             string newValue = valueState.GetString() ?? "";
             Value = newValue;
             await ValueChangeEvent.InvokeAsync(newValue);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         [JSInvokable]
-        public async void IxBlur()
+        public async Task IxBlur()
         {
             await IxBlurEvent.InvokeAsync();
         }
 
         [JSInvokable]
-        public async void ValidityStateChange(JsonElement validityState)
+        public async Task ValidityStateChange(ValidityState validityState)
         {
             await ValidityStateChangeEvent.InvokeAsync(validityState);
+        }
+
+        [JSInvokable]
+        public async Task IxChange(JsonElement valueState)
+        {
+            await IxChangeEvent.InvokeAsync(valueState.GetString() ?? string.Empty);
         }
     }
 }

--- a/SiemensIXBlazor/Enums/Input/InputType.cs
+++ b/SiemensIXBlazor/Enums/Input/InputType.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.Input
+{
+    public enum InputType
+    {
+        Text,
+        Email,
+        Password,
+        Tel,
+        Url
+    }
+}

--- a/SiemensIXBlazor/Enums/Input/TextAlignment.cs
+++ b/SiemensIXBlazor/Enums/Input/TextAlignment.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.Input
+{
+    public enum TextAlignment
+    {
+        Start,
+        End
+    }
+}

--- a/SiemensIXBlazor/Enums/TextArea/TextAreaResizeBehavior.cs
+++ b/SiemensIXBlazor/Enums/TextArea/TextAreaResizeBehavior.cs
@@ -1,0 +1,19 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.TextArea
+{
+    public enum TextAreaResizeBehavior
+    {
+        Both,
+        Horizontal,
+        Vertical,
+        None
+    }
+}

--- a/SiemensIXBlazor/Interops/BaseInterop.cs
+++ b/SiemensIXBlazor/Interops/BaseInterop.cs
@@ -34,6 +34,18 @@ namespace SiemensIXBlazor.Interops
             await module.InvokeVoidAsync("setElementProperty", id, propertyName, propertyValue);
         }
 
+        public async ValueTask<T> InvokeMethod<T>(string id, string methodName)
+        {
+            var module = await moduleTask.Value;
+            return await module.InvokeAsync<T>("invokeMethod", id, methodName);
+        }
+
+        public async ValueTask InvokeVoidMethod(string id, string methodName)
+        {
+            var module = await moduleTask.Value;
+            await module.InvokeVoidAsync("invokeVoidMethod", id, methodName);
+        }
+
         public async ValueTask DisposeAsync()
         {
             if (moduleTask.IsValueCreated)

--- a/SiemensIXBlazor/Objects/ValidityState.cs
+++ b/SiemensIXBlazor/Objects/ValidityState.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Objects
+{
+    public sealed class ValidityState
+    {
+        public bool BadInput { get; set; }
+        public bool CustomError { get; set; }
+        public bool PatternMismatch { get; set; }
+        public bool RangeOverflow { get; set; }
+        public bool RangeUnderflow { get; set; }
+        public bool StepMismatch { get; set; }
+        public bool TooLong { get; set; }
+        public bool TooShort { get; set; }
+        public bool TypeMismatch { get; set; }
+        public bool Valid { get; set; }
+        public bool ValueMissing { get; set; }
+    }
+}

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/baseJsInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/baseJsInterop.js
@@ -28,3 +28,41 @@ export function setElementProperty(elementId, propertyName, propertyValue) {
 
   element[propertyName] = propertyValue;
 }
+
+export async function invokeMethod(elementId, methodName) {
+  const element = document.getElementById(elementId);
+
+  if (!element) {
+    throw new Error(`Element with ID ${elementId} not found`);
+  }
+
+  const result = await element[methodName]();
+
+  if (methodName === 'getValidityState' && result) {
+    return {
+      badInput: result.badInput,
+      customError: result.customError,
+      patternMismatch: result.patternMismatch,
+      rangeOverflow: result.rangeOverflow,
+      rangeUnderflow: result.rangeUnderflow,
+      stepMismatch: result.stepMismatch,
+      tooLong: result.tooLong,
+      tooShort: result.tooShort,
+      typeMismatch: result.typeMismatch,
+      valid: result.valid,
+      valueMissing: result.valueMissing,
+    };
+  }
+
+  return result;
+}
+
+export async function invokeVoidMethod(elementId, methodName) {
+  const element = document.getElementById(elementId);
+
+  if (!element) {
+    throw new Error(`Element with ID ${elementId} not found`);
+  }
+
+  await element[methodName]();
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

The form-field wrappers were missing several public IX APIs and had inconsistent event, validation, and value handling. CustomField also contained unsupported upload-specific behavior, while FieldLabel and HelperText wrappers were missing.

GitHub Issue Number: #256

## 🆕 What is the new behavior?

- Align Input, NumberInput, and TextArea with the official public properties, defaults, slots, typed enums, and callbacks.
- Add `ixChange`, validation-state, blur, and nullable NumberInput value handling.
- Add shared interop support for official focus and validity methods.
- Add FieldLabel and HelperText wrappers with their documented properties.
- Remove unsupported CustomField upload behavior and retain its official default content slot.
- Update component tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)