### PR TITLE
feat(card): complete card family wrappers and slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,15 +514,17 @@ Test content
 ## Card
 
 ```razor
-<Card Variant="CardVariant.info">
-    <ix-icon name="capacity"></ix-icon>
-    <ix-typography bold>Number of components</ix-typography>
-    <ix-typography>
-        Item 1<br />
-        Item 2<br />
-        Item 3
-    </ix-typography>
-    <ix-typography format="h1">3</ix-typography>
+<Card Variant="CardVariant.info" Selected="true">
+    <CardTitle>
+        <ChildContent>Components</ChildContent>
+        <TitleActions>
+            <span>Details</span>
+        </TitleActions>
+    </CardTitle>
+    <p>Card content is rendered in the default slot.</p>
+    <CardAccordion Variant="CardAccordionVariant.info">
+        <p>Expandable card content.</p>
+    </CardAccordion>
 </Card>
 ```
 
@@ -553,10 +555,14 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
 
 ```razor
 <PushCard Icon="rocket"
+        AriaLabelIcon="Status"
         Notification="3"
         Heading="Heading content"
         SubHeading="Subheading"
-        Variant="PushCardVariant.outline"></PushCard>
+        Variant="PushCardVariant.outline">
+    <TitleAction>Action</TitleAction>
+    <ChildContent><p>Expandable content.</p></ChildContent>
+</PushCard>
 ```
 
 ## Action Card
@@ -566,8 +572,9 @@ ShowAllClickEvent="CardListShowAllClicked" ShowMoreCardClickEvent="CardListShowM
       Icon="refresh"
       Heading="Scan for new devices"
       SubHeading="Secondary text"
-      Variant="PushCardVariant.filled"
-></ActionCard>
+      Variant="ActionCardVariant.filled">
+    <span>Additional non-interactive content</span>
+</ActionCard>
 ```
 
 ## Icon Button

--- a/SiemensIXBlazor.Tests/ActionCardTests.cs
+++ b/SiemensIXBlazor.Tests/ActionCardTests.cs
@@ -9,7 +9,7 @@
 
 using Bunit;
 using SiemensIXBlazor.Components;
-using SiemensIXBlazor.Enums.PushCard;
+using SiemensIXBlazor.Enums.ActionCard;
 
 namespace SiemensIXBlazor.Tests 
 {
@@ -63,16 +63,17 @@ namespace SiemensIXBlazor.Tests
 
             // Assert
             Assert.True(cut.Instance.Selected);
+            Assert.Contains("selected", cut.Markup);
         }
 
         [Fact]
         public void VariantPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Variant, PushCardVariant.outline));
+            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Variant, ActionCardVariant.outline));
 
             // Assert
-            Assert.Equal(PushCardVariant.outline, cut.Instance.Variant);
+            Assert.Equal(ActionCardVariant.outline, cut.Instance.Variant);
         }
 
         [Fact]
@@ -96,6 +97,15 @@ namespace SiemensIXBlazor.Tests
             // Assert
             Assert.True(cut.Instance.Passive);
             Assert.Contains("passive", cut.Markup);
+        }
+
+        [Fact]
+        public void RendersDefaultContent()
+        {
+            var cut = RenderComponent<ActionCard>(parameters => parameters
+                .Add(p => p.ChildContent, builder => builder.AddContent(0, "Additional content")));
+
+            Assert.Contains("Additional content", cut.Markup);
         }
     }
 }

--- a/SiemensIXBlazor.Tests/CardAccordionTests.cs
+++ b/SiemensIXBlazor.Tests/CardAccordionTests.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Bunit;
+using SiemensIXBlazor.Components;
+using SiemensIXBlazor.Enums.CardAccordion;
+
+namespace SiemensIXBlazor.Tests;
+
+public class CardAccordionTests : TestContextBase
+{
+    [Fact]
+    public void RendersOfficialPropertiesAndContent()
+    {
+        var cut = RenderComponent<CardAccordion>(parameters => parameters
+            .Add(p => p.AriaLabelExpandButton, "Expand card")
+            .Add(p => p.Collapse, true)
+            .Add(p => p.Variant, CardAccordionVariant.success)
+            .Add(p => p.ChildContent, builder => builder.AddContent(0, "Accordion content")));
+
+        cut.MarkupMatches("<ix-card-accordion slot=\"card-accordion\" aria-label-expand-button=\"Expand card\" collapse=\"\" variant=\"success\">Accordion content</ix-card-accordion>");
+    }
+
+    [Fact]
+    public void CollapseAndVariantHaveOfficialDefaults()
+    {
+        var cut = RenderComponent<CardAccordion>();
+
+        Assert.False(cut.Instance.Collapse);
+        Assert.Equal(CardAccordionVariant.outline, cut.Instance.Variant);
+        Assert.DoesNotContain("collapse", cut.Markup);
+        Assert.Contains("variant=\"outline\"", cut.Markup);
+        Assert.Contains("slot=\"card-accordion\"", cut.Markup);
+    }
+}

--- a/SiemensIXBlazor.Tests/CardTests.cs
+++ b/SiemensIXBlazor.Tests/CardTests.cs
@@ -25,7 +25,7 @@ namespace SiemensIXBlazor.Tests
             });
 
             // Assert
-            cut.MarkupMatches("<ix-card variant=\"neutral\" selected=\"\">\r\n      <ix-card-content></ix-card-content>\r\n    </ix-card>");
+            cut.MarkupMatches("<ix-card variant=\"neutral\" selected=\"\"></ix-card>");
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace SiemensIXBlazor.Tests
                 }));
 
             // Assert
-            cut.MarkupMatches("<ix-card variant=\"outline\">\r\n      <ix-card-content>Expected content</ix-card-content>\r\n    </ix-card>");
+            cut.MarkupMatches("<ix-card variant=\"outline\">Expected content</ix-card>");
         }
 
         [Fact]
@@ -66,6 +66,15 @@ namespace SiemensIXBlazor.Tests
             // Assert
             Assert.True(cut.Instance.Passive);
             Assert.Contains("passive", cut.Markup);
+        }
+
+        [Fact]
+        public void SelectedDefaultsToFalse()
+        {
+            var cut = RenderComponent<Card>();
+
+            Assert.False(cut.Instance.Selected);
+            Assert.DoesNotContain("selected", cut.Markup);
         }
     }
 }

--- a/SiemensIXBlazor.Tests/CardTitleTests.cs
+++ b/SiemensIXBlazor.Tests/CardTitleTests.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Bunit;
+using SiemensIXBlazor.Components;
+
+namespace SiemensIXBlazor.Tests;
+
+public class CardTitleTests : TestContextBase
+{
+    [Fact]
+    public void RendersDefaultAndTitleActionsSlots()
+    {
+        var cut = RenderComponent<CardTitle>(parameters => parameters
+            .Add(p => p.ChildContent, builder => builder.AddContent(0, "Title"))
+            .Add(p => p.TitleActions, builder => builder.AddContent(0, "Actions")));
+
+        Assert.Contains("Title", cut.Markup);
+        Assert.Contains("slot=\"title-actions\"", cut.Markup);
+        Assert.Contains("Actions", cut.Markup);
+    }
+}

--- a/SiemensIXBlazor.Tests/PushCardTest.cs
+++ b/SiemensIXBlazor.Tests/PushCardTest.cs
@@ -22,6 +22,7 @@ namespace SiemensIXBlazor.Tests
             var cut = RenderComponent<PushCard>(
                 ("Heading", "Test Heading"),
                 ("Icon", "testIcon"),
+                ("AriaLabelIcon", "Test icon"),
                 ("Notification", "5"),
                 ("SubHeading", "Test SubHeading"),
                 ("Expanded", true),
@@ -30,7 +31,7 @@ namespace SiemensIXBlazor.Tests
 
             // Assert
 
-            cut.MarkupMatches("<ix-push-card heading=\"Test Heading\" icon=\"testIcon\" notification=\"5\" subheading=\"Test SubHeading\" expanded=\"\" variant=\"outline\"></ix-push-card>");
+            cut.MarkupMatches("<ix-push-card aria-label-icon=\"Test icon\" heading=\"Test Heading\" icon=\"testIcon\" notification=\"5\" subheading=\"Test SubHeading\" expanded=\"\" variant=\"outline\"></ix-push-card>");
         }
 
         [Fact]
@@ -54,6 +55,27 @@ namespace SiemensIXBlazor.Tests
             // Assert
             Assert.True(cut.Instance.Passive);
             Assert.Contains("passive", cut.Markup);
+        }
+
+        [Fact]
+        public void ExpandedDefaultsToFalse()
+        {
+            var cut = RenderComponent<PushCard>();
+
+            Assert.False(cut.Instance.Expanded);
+            Assert.DoesNotContain("expanded", cut.Markup);
+        }
+
+        [Fact]
+        public void RendersDefaultAndTitleActionContent()
+        {
+            var cut = RenderComponent<PushCard>(parameters => parameters
+                .Add(p => p.ChildContent, builder => builder.AddContent(0, "Details"))
+                .Add(p => p.TitleAction, builder => builder.AddContent(0, "Action")));
+
+            Assert.Contains("slot=\"title-action\"", cut.Markup);
+            Assert.Contains("Action", cut.Markup);
+            Assert.Contains("Details", cut.Markup);
         }
     }
 }

--- a/SiemensIXBlazor/Components/ActionCard/ActionCard.razor
+++ b/SiemensIXBlazor/Components/ActionCard/ActionCard.razor
@@ -10,7 +10,7 @@
 
 @namespace SiemensIXBlazor.Components
 @using SiemensIXBlazor.Helpers
-@using SiemensIXBlazor.Enums.PushCard
+@using SiemensIXBlazor.Enums.ActionCard
 @inherits IXBaseComponent
 
 <ix-action-card @attributes="UserAttributes"
@@ -19,8 +19,10 @@
                 icon="@Icon"
                 heading="@Heading"
                 subheading="@SubHeading"
+                selected="@Selected"
                 aria-label-card="@AriaLabelCard"
                 aria-label-icon="@AriaLabelIcon"
                 passive="@Passive"
-                variant="@(EnumParser<PushCardVariant>.EnumToString(Variant))">
+                variant="@(EnumParser<ActionCardVariant>.EnumToString(Variant))">
+    @ChildContent
 </ix-action-card>

--- a/SiemensIXBlazor/Components/ActionCard/ActionCard.razor.cs
+++ b/SiemensIXBlazor/Components/ActionCard/ActionCard.razor.cs
@@ -9,12 +9,15 @@
 
 using System;
 using Microsoft.AspNetCore.Components;
-using SiemensIXBlazor.Enums.PushCard;
+using SiemensIXBlazor.Enums.ActionCard;
 
 namespace SiemensIXBlazor.Components
 {
 	public partial class ActionCard
 	{
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+
         [Parameter]
         public string? AriaLabelCard { get; set; }
 
@@ -49,7 +52,6 @@ namespace SiemensIXBlazor.Components
         /// Card variant
         /// </summary>
         [Parameter]
-        public PushCardVariant Variant { get; set; } = PushCardVariant.outline;
+        public ActionCardVariant Variant { get; set; } = ActionCardVariant.outline;
     }
 }
-

--- a/SiemensIXBlazor/Components/Card/Card.razor
+++ b/SiemensIXBlazor/Components/Card/Card.razor
@@ -15,12 +15,8 @@
 <ix-card @attributes="UserAttributes"
          class=@Class
          style=@Style
-         aria-label-card="@AriaLabelCard"
-         aria-label-icon="@AriaLabelIcon"
          variant=@Variant
          selected=@Selected
          passive=@Passive>
-    <ix-card-content>
-        @ChildContent
-    </ix-card-content>
+    @ChildContent
 </ix-card>

--- a/SiemensIXBlazor/Components/Card/Card.razor.cs
+++ b/SiemensIXBlazor/Components/Card/Card.razor.cs
@@ -15,11 +15,7 @@ namespace SiemensIXBlazor.Components
     public partial class Card
     {
         [Parameter]
-        public string? AriaLabelCard { get; set; }
-        [Parameter]
-        public string? AriaLabelIcon { get; set; }  
-        [Parameter]
-        public bool? Selected { get; set; }
+        public bool Selected { get; set; } = false;
         [Parameter]
         public bool Passive { get; set; } = false;
         [Parameter]

--- a/SiemensIXBlazor/Components/CardAccordion/CardAccordion.razor
+++ b/SiemensIXBlazor/Components/CardAccordion/CardAccordion.razor
@@ -1,0 +1,24 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+*@
+
+@namespace SiemensIXBlazor.Components
+@using SiemensIXBlazor.Enums.CardAccordion
+@using SiemensIXBlazor.Helpers
+@inherits IXBaseComponent
+
+<ix-card-accordion @attributes="UserAttributes"
+                   class="@Class"
+                   style="@Style"
+                   slot="card-accordion"
+                   aria-label-expand-button="@AriaLabelExpandButton"
+                   collapse="@Collapse"
+                   variant="@(EnumParser<CardAccordionVariant>.EnumToString(Variant))">
+    @ChildContent
+</ix-card-accordion>

--- a/SiemensIXBlazor/Components/CardAccordion/CardAccordion.razor.cs
+++ b/SiemensIXBlazor/Components/CardAccordion/CardAccordion.razor.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using SiemensIXBlazor.Enums.CardAccordion;
+
+namespace SiemensIXBlazor.Components
+{
+    public partial class CardAccordion
+    {
+        [Parameter]
+        public string? AriaLabelExpandButton { get; set; }
+
+        [Parameter]
+        public bool Collapse { get; set; } = false;
+
+        [Parameter]
+        public CardAccordionVariant Variant { get; set; } = CardAccordionVariant.outline;
+
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+    }
+}

--- a/SiemensIXBlazor/Components/CardTitle/CardTitle.razor
+++ b/SiemensIXBlazor/Components/CardTitle/CardTitle.razor
@@ -1,0 +1,22 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+*@
+
+@namespace SiemensIXBlazor.Components
+@inherits IXBaseComponent
+
+<ix-card-title @attributes="UserAttributes"
+               class="@Class"
+               style="@Style">
+    @ChildContent
+    @if (TitleActions is not null)
+    {
+        <div slot="title-actions">@TitleActions</div>
+    }
+</ix-card-title>

--- a/SiemensIXBlazor/Components/CardTitle/CardTitle.razor.cs
+++ b/SiemensIXBlazor/Components/CardTitle/CardTitle.razor.cs
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace SiemensIXBlazor.Components
+{
+    public partial class CardTitle
+    {
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+
+        [Parameter]
+        public RenderFragment? TitleActions { get; set; }
+    }
+}

--- a/SiemensIXBlazor/Components/PushCard/PushCard.razor
+++ b/SiemensIXBlazor/Components/PushCard/PushCard.razor
@@ -17,10 +17,16 @@
               class="@Class"
               style="@Style"
               icon="@Icon"
+              aria-label-icon="@AriaLabelIcon"
               notification="@Notification"
               heading="@Heading"
               subheading="@SubHeading"
               expanded="@Expanded"
               passive="@Passive"
               variant="@(EnumParser<PushCardVariant>.EnumToString(Variant))">
+    @if (TitleAction is not null)
+    {
+        <div slot="title-action">@TitleAction</div>
+    }
+    @ChildContent
 </ix-push-card>

--- a/SiemensIXBlazor/Components/PushCard/PushCard.razor.cs
+++ b/SiemensIXBlazor/Components/PushCard/PushCard.razor.cs
@@ -14,6 +14,12 @@ namespace SiemensIXBlazor.Components
 {
     public partial class PushCard
     {
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+
+        [Parameter]
+        public RenderFragment? TitleAction { get; set; }
+
         /// <summary>
         /// Card heading
         /// </summary>
@@ -25,6 +31,11 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? Icon { get; set; }
         /// <summary>
+        /// ARIA label for the icon
+        /// </summary>
+        [Parameter]
+        public string? AriaLabelIcon { get; set; }
+        /// <summary>
         /// Card KPI value
         /// </summary>
         [Parameter]
@@ -35,7 +46,7 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public string? SubHeading { get; set; }
         [Parameter]
-        public bool Expanded { get; set; } = true;
+        public bool Expanded { get; set; } = false;
         /// <summary>
         /// If true, disables hover and active styles and changes cursor to default
         /// </summary>
@@ -48,4 +59,3 @@ namespace SiemensIXBlazor.Components
         public PushCardVariant Variant { get; set; } = PushCardVariant.outline;
     }
 }
-

--- a/SiemensIXBlazor/Enums/ActionCard/ActionCardVariant.cs
+++ b/SiemensIXBlazor/Enums/ActionCard/ActionCardVariant.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.ActionCard
+{
+    public enum ActionCardVariant
+    {
+        alarm,
+        critical,
+        warning,
+        info,
+        neutral,
+        success,
+        primary,
+        outline,
+        filled
+    }
+}

--- a/SiemensIXBlazor/Enums/CardAccordion/CardAccordionVariant.cs
+++ b/SiemensIXBlazor/Enums/CardAccordion/CardAccordionVariant.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums.CardAccordion
+{
+    public enum CardAccordionVariant
+    {
+        alarm,
+        critical,
+        warning,
+        info,
+        neutral,
+        success,
+        primary,
+        outline,
+        filled
+    }
+}

--- a/SiemensIXBlazor/Enums/PushCard/PushCardVariant.cs
+++ b/SiemensIXBlazor/Enums/PushCard/PushCardVariant.cs
@@ -17,6 +17,7 @@ namespace SiemensIXBlazor.Enums.PushCard
 		neutral,
 		outline,
 		filled,
+		primary,
 		success,
 		warning
 	}


### PR DESCRIPTION
## 💡 What is the current behavior?

The Card family was missing several official public APIs and slot mappings. Card also exposed unsupported accessibility parameters and wrapped its default content in an unsupported element. PushCard had an incorrect expanded default and incomplete slot/accessibility support, while CardAccordion and CardTitle wrappers were missing.

GitHub Issue Number: #255

## 🆕 What is the new behavior?

- Align `Card`, `ActionCard`, and `PushCard` properties, defaults, variants, selection, and accessibility attributes with the official IX API.
- Add `CardAccordion` and `CardTitle` wrappers with their documented properties and slots.
- Map default content, card-accordion, title-actions, and title-action slots correctly.
- Remove unsupported Card accessibility parameters and the internal accordion event.
- Update component tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)