### PR TITLE
feat(tree): complete tree and tree item parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,11 +1341,17 @@ await toast.ShowToast(configWithAction);
 
 ```razor
 <div style="height: 8rem; width: 100%">
-    <Tree Id="tree-1" Root="root" ContextChangedEvent="TreeContextChangeEvent"
-    NodeClickedEvent="TreeNodeClicked"
-    NodeRemovedEvent="NodeRemoved"
-    NodeToggledEvent="TreeNodeToggled"
-    @ref="tree"></Tree>
+    <Tree Id="tree-1"
+          Root="root"
+          Model="@treeNodes"
+          Context="@treeContext"
+          ToggleOnItemClick="true"
+          ContextChangedEvent="TreeContextChangeEvent"
+          NodeClickedEvent="TreeNodeClicked"
+          NodeRemovedEvent="NodeRemoved"
+          NodeToggledEvent="TreeNodeToggled"
+          @ref="tree">
+    </Tree>
 </div>
 ```
 
@@ -1380,6 +1386,7 @@ treeNodes.Add("sample-child-1", new TreeNode()
         Name = "Sample Child 1",
         Icon = "star"
     },
+    Disabled = false,
     HasChildren = false,
     Children = new List<string>() {}
 });
@@ -1393,10 +1400,29 @@ treeNodes.Add("sample-child-2", new TreeNode()
         },
         HasChildren = false,
         Children = new List<string>() { }
-    });
+});
 
+Dictionary<string, TreeContextNode> treeContext = new()
+{
+    ["sample"] = new TreeContextNode { IsExpanded = true, IsSelected = false },
+    ["sample-child-1"] = new TreeContextNode { IsExpanded = false, IsSelected = true }
+};
 
-tree.TreeModel = treeNodes;
+// Update data through the component parameters, or call the public methods:
+await tree.MarkItemsAsDirty("sample-child-1");
+await tree.RefreshTree(new RefreshTreeOptions { Force = true });
+```
+
+Use `TreeItem` for a standalone official tree item, including custom content:
+
+```razor
+<TreeItem Text="Custom item"
+          HasChildren="true"
+          Context="@treeItemContext"
+          ToggleEvent="OnTreeItemToggle"
+          ItemClickEvent="OnTreeItemClick">
+    Custom content
+</TreeItem>
 ```
 
 ## Typography

--- a/SiemensIXBlazor.Tests/TreeTests.cs
+++ b/SiemensIXBlazor.Tests/TreeTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2025 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -9,12 +9,8 @@
 
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.JSInterop;
-using Moq;
 using SiemensIXBlazor.Components.Tree;
 using SiemensIXBlazor.Objects;
-using System.Diagnostics;
 using System.Text.Json;
 
 namespace SiemensIXBlazor.Tests;
@@ -22,256 +18,109 @@ namespace SiemensIXBlazor.Tests;
 public class TreeTests : TestContextBase
 {
     [Fact]
-    public void Render_WithRequiredParameters_ShouldRenderTreeComponent()
+    public void Render_WithOfficialTreeProperties_ShouldRenderTreeComponent()
     {
-        // Arrange & Act
+        var model = new Dictionary<string, TreeNode>
+        {
+            ["root"] = new() { Id = "root", HasChildren = true, Children = ["node"] },
+            ["node"] = new() { Id = "node", Data = new TreeData { Name = "Node" } }
+        };
+
         var cut = RenderComponent<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-id")
-        );
+            .Add(p => p.Root, "root")
+            .Add(p => p.Model, model)
+            .Add(p => p.ToggleOnItemClick, true)
+            .AddChildContent("Slotted content"));
 
-        // Assert
-        cut.MarkupMatches(@"<ix-tree id=""tree-id""></ix-tree>");
+        var tree = cut.Find("ix-tree");
+        Assert.Equal("tree-id", tree.GetAttribute("id"));
+        Assert.Equal("root", tree.GetAttribute("root"));
+        Assert.Contains("Slotted content", cut.Markup);
     }
 
     [Fact]
-    public async Task ContextChanged_ShouldInvokeContextChangedEvent()
+    public async Task ContextChanged_ShouldDeserializeDisabledState()
     {
-        // Arrange
         var cut = RenderComponent<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-id")
-        );
+            .Add(p => p.ContextChangedEvent, EventCallback.Factory.Create<Dictionary<string, TreeContextNode>>(
+                this, _ => { })));
 
         Dictionary<string, TreeContextNode>? receivedContext = null;
-        await cut.InvokeAsync(() => cut.Instance.ContextChangedEvent.InvokeAsync(new Dictionary<string, TreeContextNode>()));
-
-        var newContext = new Dictionary<string, TreeContextNode>
-        {
-            { "node1", new TreeContextNode { IsExpanded = true, IsSelected = false } }
-        };
-
-        var json = JsonSerializer.Serialize(newContext);
-        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
-
         cut.SetParametersAndRender(parameters => parameters
-            .Add(p => p.ContextChangedEvent, EventCallback.Factory.Create<Dictionary<string, TreeContextNode>>(this, ctx => receivedContext = ctx))
-        );
+            .Add(p => p.ContextChangedEvent, EventCallback.Factory.Create<Dictionary<string, TreeContextNode>>(
+                this, context => receivedContext = context)));
 
-        // Act
-        await cut.Instance.ContextChanged(jsonElement);
+        using var document = JsonDocument.Parse("{\"node1\":{\"isExpanded\":true,\"isSelected\":false,\"isDisabled\":true}}");
+        await cut.Instance.ContextChanged(document.RootElement);
 
-        // Assert
         Assert.NotNull(receivedContext);
-        Assert.True(receivedContext!.ContainsKey("node1"));
-        Assert.True(receivedContext["node1"].IsExpanded);
+        Assert.True(receivedContext!["node1"].IsExpanded);
+        Assert.True(receivedContext["node1"].IsDisabled);
     }
 
     [Fact]
-    public async Task NodeRemoved_ShouldInvokeNodeRemovedEvent()
+    public async Task NodeToggled_ShouldExposeOfficialIsExpandedProperty()
     {
-        // Arrange
         var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-id")
-        );
-
-        var eventTriggered = false;
+            .Add(p => p.Id, "tree-id"));
+        TreeNodeToggledEventResult? result = null;
 
         cut.SetParametersAndRender(parameters => parameters
-            .Add(p => p.NodeRemovedEvent, EventCallback.Factory.Create(this, () => eventTriggered = true))
-        );
+            .Add(p => p.NodeToggledEvent, EventCallback.Factory.Create<TreeNodeToggledEventResult>(
+                this, value => result = value)));
 
-        // Act
-        await cut.InvokeAsync(() => cut.Instance.NodeRemoved());
+        using var document = JsonDocument.Parse("{\"id\":\"node1\",\"isExpanded\":true}");
+        await cut.Instance.NodeToggled(document.RootElement);
 
-        // Assert
-        Assert.True(eventTriggered);
+        Assert.NotNull(result);
+        Assert.Equal("node1", result!.Id);
+        Assert.True(result.IsExpanded);
     }
 
     [Fact]
-    public async Task NodeClicked_ShouldInvokeNodeClickedEvent()
+    public async Task TreeMethods_ShouldAcceptOfficialMethodShapes()
     {
-        // Arrange
         var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-id")
-        );
+            .Add(p => p.Id, "tree-methods"));
 
-        string? clickedNode = null;
-
-        cut.SetParametersAndRender(parameters => parameters
-            .Add(p => p.NodeClickedEvent, EventCallback.Factory.Create<string>(this, node => clickedNode = node))
-        );
-
-        // Act
-        await cut.InvokeAsync(() => cut.Instance.NodeClicked("node1"));
-
-        // Assert
-        Assert.Equal("node1", clickedNode);
+        await cut.Instance.MarkItemsAsDirty("item1", "item2");
+        await cut.Instance.RefreshTree(new RefreshTreeOptions { Force = true });
     }
 
     [Fact]
-    public async Task NodeToggled_ShouldInvokeNodeToggledEvent()
+    public void TreeNode_ShouldSerializeDisabledProperty()
     {
-        // Arrange
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-id")
-        );
+        var node = new TreeNode { Id = "node", Disabled = true };
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(node);
 
-        TreeNodeToggledEventResult? toggledNodeResult = null;
-
-        cut.SetParametersAndRender(parameters => parameters
-            .Add(p => p.NodeToggledEvent, EventCallback.Factory.Create<TreeNodeToggledEventResult>(this, node => toggledNodeResult = node))
-        );
-
-        var toggledNode = new TreeNodeToggledEventResult
-        {
-            Id = "node1",
-            IsExpaned = true
-        };
-
-        var json = JsonSerializer.Serialize(toggledNode);
-        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
-
-        // Act
-        await cut.InvokeAsync(() => cut.Instance.NodeToggled(jsonElement));
-
-        // Assert
-        Assert.NotNull(toggledNodeResult);
-        Assert.Equal("node1", toggledNodeResult!.Id);
-        Assert.True(toggledNodeResult.IsExpaned);
+        Assert.Contains("\"disabled\":true", json);
     }
 
     [Fact]
-    public async Task OnAfterRenderAsync_FirstRender_AttachesListeners()
+    public async Task TreeItem_ShouldRenderPropertiesAndInvokeEvents()
     {
-        // Arrange
-        var jsRuntimeMock = new Mock<IJSRuntime>();
-        var jsObjectReferenceMock = new Mock<IJSObjectReference>();
+        var toggled = false;
+        var clicked = false;
 
-        jsRuntimeMock
-            .Setup(js => js.InvokeAsync<IJSObjectReference>(
-                "import",
-                It.IsAny<object[]>()
-            ))
-            .ReturnsAsync(jsObjectReferenceMock.Object);
+        var cut = RenderComponent<TreeItem>(parameters => parameters
+            .Add(p => p.Text, "Node")
+            .Add(p => p.HasChildren, true)
+            .Add(p => p.Disabled, true)
+            .Add(p => p.Context, new TreeContextNode { IsSelected = true, IsDisabled = true })
+            .Add(p => p.ToggleEvent, EventCallback.Factory.Create(this, () => toggled = true))
+            .Add(p => p.ItemClickEvent, EventCallback.Factory.Create(this, () => clicked = true))
+            .AddChildContent("Custom content"));
 
-        jsObjectReferenceMock
-            .Setup(js => js.InvokeAsync<string>(
-                It.IsAny<string>(),
-                It.IsAny<object[]>()
-            ))
-            .ReturnsAsync("fakeEventId");
+        var item = cut.Find("ix-tree-item");
+        Assert.Equal("Node", item.GetAttribute("text"));
+        Assert.Contains("Custom content", cut.Markup);
 
-        Services.AddSingleton(jsRuntimeMock.Object);
+        await cut.Instance.Toggle();
+        await cut.Instance.ItemClick();
 
-        // Act
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-js")
-        );
-
-        var timeout = TimeSpan.FromSeconds(10);
-        var stopwatch = Stopwatch.StartNew();
-        bool verificationSucceeded = false;
-
-        while (!verificationSucceeded && stopwatch.Elapsed < timeout)
-        {
-            try
-            {
-                jsObjectReferenceMock.Verify(js => js.InvokeAsync<string>(
-                    It.Is<string>(s => s == "listenEvent"),
-                    It.Is<object[]>(args =>
-                        args.Length >= 4 &&
-                        args[1]!.ToString() == "tree-js" &&
-                        args[2]!.ToString() == "contextChange" &&
-                        args[3]!.ToString() == "ContextChanged"
-                    )
-                ), Times.AtLeastOnce());
-
-                verificationSucceeded = true;
-            }
-            catch
-            {
-                await Task.Delay(100);
-            }
-        }
-
-        if (!verificationSucceeded)
-        {
-            jsObjectReferenceMock.Verify(js => js.InvokeAsync<string>(
-                It.Is<string>(s => s == "listenEvent"),
-                It.Is<object[]>(args =>
-                    args.Length >= 4 &&
-                    args[1]!.ToString() == "tree-js" &&
-                    args[2]!.ToString() == "contextChange" &&
-                    args[3]!.ToString() == "ContextChanged"
-                )
-            ), Times.AtLeastOnce());
-        }
-    }
-
-    [Fact]
-    public void TreeData_WithIcon_ShouldSerializeCorrectly()
-    {
-        // Arrange
-        var treeData = new TreeData
-        {
-            Name = "Test Node",
-            Icon = "star"
-        };
-
-        // Act
-        var json = Newtonsoft.Json.JsonConvert.SerializeObject(treeData);
-
-        // Assert
-        Assert.Contains("\"name\":\"Test Node\"", json);
-        Assert.Contains("\"icon\":\"star\"", json);
-    }
-
-    [Fact]
-    public async Task MarkItemAsDirty_WithValidIdentifiers_ExecutesSuccessfully()
-    {
-        // Arrange
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-mark-dirty")
-        );
-
-        string[] itemIdentifiers = new[] { "item1", "item2", "item3" };
-
-        // Act & Assert
-        await cut.InvokeAsync(async () => await cut.Instance.MarkItemAsDirty(itemIdentifiers));
-    }
-
-    [Fact]
-    public async Task MarkItemAsDirty_WithSingleIdentifier_ExecutesSuccessfully()
-    {
-        // Arrange
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-mark-dirty-single")
-        );
-
-        // Act & Assert
-        await cut.InvokeAsync(async () => await cut.Instance.MarkItemAsDirty("item1"));
-    }
-
-    [Fact]
-    public async Task MarkItemAsDirty_WithEmptyArray_ExecutesSuccessfully()
-    {
-        // Arrange
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-mark-dirty-empty")
-        );
-
-        // Act & Assert
-        await cut.InvokeAsync(async () => await cut.Instance.MarkItemAsDirty(Array.Empty<string>()));
-    }
-
-    [Fact]
-    public async Task MarkItemAsDirty_WithNullArray_ExecutesSuccessfully()
-    {
-        // Arrange
-        var cut = RenderComponent<Tree>(parameters => parameters
-            .Add(p => p.Id, "tree-mark-dirty-null")
-        );
-
-        // Act & Assert
-        await cut.InvokeAsync(async () => await cut.Instance.MarkItemAsDirty(null!));
+        Assert.True(toggled);
+        Assert.True(clicked);
     }
 }

--- a/SiemensIXBlazor/Components/Tree/Tree.razor
+++ b/SiemensIXBlazor/Components/Tree/Tree.razor
@@ -17,4 +17,4 @@
 class="@Class"
 style="@Style"
 root="@Root" 
-id="@Id"></ix-tree>
+id="@Id">@ChildContent</ix-tree>

--- a/SiemensIXBlazor/Components/Tree/Tree.razor.cs
+++ b/SiemensIXBlazor/Components/Tree/Tree.razor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -14,121 +14,141 @@ using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects;
 using System.Text.Json;
 
-namespace SiemensIXBlazor.Components.Tree
+namespace SiemensIXBlazor.Components.Tree;
+
+public partial class Tree
 {
-    public partial class Tree
+    private Lazy<Task<IJSObjectReference>>? _moduleTask;
+    private BaseInterop? _interop;
+    private string? _lastModel;
+    private string? _lastContext;
+    private bool? _lastToggleOnItemClick;
+
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+
+    [Parameter]
+    public Dictionary<string, TreeNode> Model { get; set; } = new();
+
+    [Parameter]
+    public Dictionary<string, TreeContextNode> Context { get; set; } = new();
+
+    [Parameter]
+    public string Root { get; set; } = "root";
+
+    [Parameter]
+    public bool ToggleOnItemClick { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public EventCallback<Dictionary<string, TreeContextNode>> ContextChangedEvent { get; set; }
+
+    [Parameter]
+    public EventCallback NodeRemovedEvent { get; set; }
+
+    [Parameter]
+    public EventCallback<string> NodeClickedEvent { get; set; }
+
+    [Parameter]
+    public EventCallback<TreeNodeToggledEventResult> NodeToggledEvent { get; set; }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        private Dictionary<string, TreeNode>? _treeModel;
-        private Dictionary<string, TreeContextNode>? _treeContext;
-        private Lazy<Task<IJSObjectReference>>? moduleTask;
-        private BaseInterop? _interop;
-
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
-        public Dictionary<string, TreeNode>? TreeModel 
+        if (firstRender)
         {
-            get => _treeModel;
-            set
-            {
-                _treeModel = value;
-                InitialParameter("setTreeModel", _treeModel);
-            } 
-        }
-        public Dictionary<string, TreeContextNode>? TreeContext 
-        {
-            get => _treeContext;
-            set
-            {
-                _treeContext = value;
-                InitialParameter("setTreeContext", _treeContext);
-            }
-        }
-        [Parameter]
-        public string? Root { get; set; }
-        [Parameter]
-        public EventCallback<Dictionary<string, TreeContextNode>> ContextChangedEvent { get; set; }
-        [Parameter]
-        public EventCallback NodeRemovedEvent { get; set; }
-        [Parameter]
-        public EventCallback<string> NodeClickedEvent { get; set; }
-        [Parameter]
-        public EventCallback<TreeNodeToggledEventResult> NodeToggledEvent { get; set; }
+            _interop = new(JSRuntime);
 
-        protected override void OnAfterRender(bool firstRender)
-        {
-            if (firstRender)
-            {
-                _interop = new(JSRuntime);
-
-                Task.Run(async () =>
-                {
-                    await _interop.AddEventListener(this, Id, "contextChange", "ContextChanged");
-                    await _interop.AddEventListener(this, Id, "nodeRemoved", "NodeRemoved");
-                    await _interop.AddEventListener(this, Id, "nodeClicked", "NodeClicked");
-                    await _interop.AddEventListener(this, Id, "nodeToggled", "NodeToggled");
-                });
-            }
+            await _interop.AddEventListener(this, Id, "contextChange", nameof(ContextChanged));
+            await _interop.AddEventListener(this, Id, "nodeRemoved", nameof(NodeRemoved));
+            await _interop.AddEventListener(this, Id, "nodeClicked", nameof(NodeClicked));
+            await _interop.AddEventListener(this, Id, "nodeToggled", nameof(NodeToggled));
         }
 
-        private void InitialParameter(string functionName, object param)
+        await ApplyPropertiesAsync();
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync()
+    {
+        _moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/treeInterop.js").AsTask());
+
+        return await _moduleTask.Value;
+    }
+
+    private async Task ApplyPropertiesAsync()
+    {
+        var module = await GetModuleAsync();
+        var model = JsonConvert.SerializeObject(Model ?? new Dictionary<string, TreeNode>());
+        var context = JsonConvert.SerializeObject(Context ?? new Dictionary<string, TreeContextNode>());
+
+        if (!string.Equals(_lastModel, model, StringComparison.Ordinal))
         {
-
-            moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/treeInterop.js").AsTask());
-
-            Task.Run(async () =>
-            {
-                var module = await moduleTask.Value;
-                if (module != null)
-                {
-                    var serObj = JsonConvert.SerializeObject(param);
-                    await module.InvokeVoidAsync(functionName, Id, JsonConvert.SerializeObject(param));
-                }
-            });
+            await module.InvokeVoidAsync("setTreeModel", Id, model);
+            _lastModel = model;
         }
 
-        [JSInvokable]
-        public async Task ContextChanged(JsonElement context)
+        if (!string.Equals(_lastContext, context, StringComparison.Ordinal))
         {
-            string jsonDataText = context.GetRawText();
-            Dictionary<string, TreeContextNode>? changedContext = JsonConvert.DeserializeObject<Dictionary<string, TreeContextNode>>(jsonDataText);
-            await ContextChangedEvent.InvokeAsync(changedContext);
+            await module.InvokeVoidAsync("setTreeContext", Id, context);
+            _lastContext = context;
         }
 
-        [JSInvokable]
-        public async Task NodeRemoved()
+        if (_lastToggleOnItemClick != ToggleOnItemClick)
         {
-            await NodeRemovedEvent.InvokeAsync();
+            await module.InvokeVoidAsync("setToggleOnItemClick", Id, ToggleOnItemClick);
+            _lastToggleOnItemClick = ToggleOnItemClick;
+        }
+    }
+
+    [JSInvokable]
+    public async Task ContextChanged(JsonElement context)
+    {
+        var changedContext = JsonConvert.DeserializeObject<Dictionary<string, TreeContextNode>>(context.GetRawText())
+            ?? new Dictionary<string, TreeContextNode>();
+        await ContextChangedEvent.InvokeAsync(changedContext);
+    }
+
+    [JSInvokable]
+    public async Task NodeRemoved()
+    {
+        await NodeRemovedEvent.InvokeAsync();
+    }
+
+    [JSInvokable]
+    public async Task NodeClicked(string nodeId)
+    {
+        await NodeClickedEvent.InvokeAsync(nodeId);
+    }
+
+    [JSInvokable]
+    public async Task NodeToggled(JsonElement toggledNode)
+    {
+        var result = JsonConvert.DeserializeObject<TreeNodeToggledEventResult>(toggledNode.GetRawText())
+            ?? new TreeNodeToggledEventResult();
+        await NodeToggledEvent.InvokeAsync(result);
+    }
+
+    public async Task MarkItemsAsDirty(params string[] itemIdentifiers)
+    {
+        if (itemIdentifiers == null || itemIdentifiers.Length == 0)
+        {
+            return;
         }
 
-        [JSInvokable]
-        public async Task NodeClicked(string label)
-        {
-            await NodeClickedEvent.InvokeAsync(label);
-        }
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("markItemsAsDirty", Id, itemIdentifiers);
+    }
 
-        [JSInvokable]
-        public async Task NodeToggled(JsonElement toggledNode)
-        {
-            string jsonDataText = toggledNode.GetRawText();
-            TreeNodeToggledEventResult result = JsonConvert.DeserializeObject<TreeNodeToggledEventResult>(jsonDataText);
-            await NodeToggledEvent.InvokeAsync(result);
-        }
+    public Task MarkItemAsDirty(params string[] itemIdentifiers)
+    {
+        return MarkItemsAsDirty(itemIdentifiers);
+    }
 
-        public async Task MarkItemAsDirty(params string[] itemIdentifiers)
-        {
-            if (_interop == null || itemIdentifiers == null || itemIdentifiers.Length == 0)
-                return;
-
-            moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/treeInterop.js").AsTask());
-
-            var module = await moduleTask.Value;
-            if (module != null)
-            {
-                await module.InvokeVoidAsync("markItemAsDirty", Id, itemIdentifiers);
-            }
-        }
-
+    public async Task RefreshTree(RefreshTreeOptions? options = null)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("refreshTree", Id, options ?? new RefreshTreeOptions());
     }
 }

--- a/SiemensIXBlazor/Components/Tree/TreeItem.razor
+++ b/SiemensIXBlazor/Components/Tree/TreeItem.razor
@@ -1,0 +1,23 @@
+@* -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+*@
+
+@using Microsoft.JSInterop
+@inject IJSRuntime JSRuntime
+@inherits IXBaseComponent
+
+<ix-tree-item
+    @attributes="UserAttributes"
+    class="@Class"
+    style="@Style"
+    id="@ElementId"
+    text="@Text"
+    aria-label-chevron-icon="@AriaLabelChevronIcon">
+    @ChildContent
+</ix-tree-item>

--- a/SiemensIXBlazor/Components/Tree/TreeItem.razor.cs
+++ b/SiemensIXBlazor/Components/Tree/TreeItem.razor.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Newtonsoft.Json;
+using SiemensIXBlazor.Interops;
+using SiemensIXBlazor.Objects;
+
+namespace SiemensIXBlazor.Components.Tree;
+
+public partial class TreeItem
+{
+    private readonly string ElementId = $"tree-item-{Guid.NewGuid():N}";
+    private Lazy<Task<IJSObjectReference>>? _moduleTask;
+    private BaseInterop? _interop;
+    private string? _lastContext;
+    private bool? _lastHasChildren;
+    private bool? _lastDisabled;
+
+    [Parameter]
+    public string? Text { get; set; }
+
+    [Parameter]
+    public bool HasChildren { get; set; }
+
+    [Parameter]
+    public TreeContextNode? Context { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter]
+    public string? AriaLabelChevronIcon { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public EventCallback ToggleEvent { get; set; }
+
+    [Parameter]
+    public EventCallback ItemClickEvent { get; set; }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interop = new(JSRuntime);
+            await _interop.AddEventListener(this, ElementId, "toggle", nameof(Toggle));
+            await _interop.AddEventListener(this, ElementId, "itemClick", nameof(ItemClick));
+        }
+
+        await ApplyPropertiesAsync();
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync()
+    {
+        _moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/Siemens.IX.Blazor/js/siemens-ix/interops/treeInterop.js").AsTask());
+
+        return await _moduleTask.Value;
+    }
+
+    private async Task ApplyPropertiesAsync()
+    {
+        var module = await GetModuleAsync();
+        var context = Context is null ? null : JsonConvert.SerializeObject(Context);
+
+        if (!string.Equals(_lastContext, context, StringComparison.Ordinal))
+        {
+            await module.InvokeVoidAsync("setTreeItemContext", ElementId, context);
+            _lastContext = context;
+        }
+
+        if (_lastHasChildren != HasChildren)
+        {
+            await module.InvokeVoidAsync("setTreeItemProperty", ElementId, "hasChildren", HasChildren);
+            _lastHasChildren = HasChildren;
+        }
+
+        if (_lastDisabled != Disabled)
+        {
+            await module.InvokeVoidAsync("setTreeItemProperty", ElementId, "disabled", Disabled);
+            _lastDisabled = Disabled;
+        }
+    }
+
+    [JSInvokable]
+    public async Task Toggle()
+    {
+        await ToggleEvent.InvokeAsync();
+    }
+
+    [JSInvokable]
+    public async Task ItemClick()
+    {
+        await ItemClickEvent.InvokeAsync();
+    }
+}

--- a/SiemensIXBlazor/Objects/RefreshTreeOptions.cs
+++ b/SiemensIXBlazor/Objects/RefreshTreeOptions.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace SiemensIXBlazor.Objects;
+
+public class RefreshTreeOptions
+{
+    [JsonProperty("force")]
+    public bool Force { get; set; }
+}

--- a/SiemensIXBlazor/Objects/TreeContextNode.cs
+++ b/SiemensIXBlazor/Objects/TreeContextNode.cs
@@ -17,5 +17,7 @@ namespace SiemensIXBlazor.Objects
         public bool IsExpanded { get; set; }
         [JsonProperty("isSelected")]
         public bool IsSelected { get; set; }
+        [JsonProperty("isDisabled")]
+        public bool? IsDisabled { get; set; }
     }
 }

--- a/SiemensIXBlazor/Objects/TreeNode.cs
+++ b/SiemensIXBlazor/Objects/TreeNode.cs
@@ -19,6 +19,8 @@ namespace SiemensIXBlazor.Objects
         public TreeData? Data { get; set; }
         [JsonProperty("hasChildren")]
         public bool HasChildren { get; set; }
+        [JsonProperty("disabled")]
+        public bool? Disabled { get; set; }
         [JsonProperty("children")]
         public List<string>? Children { get; set; }
     }

--- a/SiemensIXBlazor/Objects/TreeNodeToggledEventResult.cs
+++ b/SiemensIXBlazor/Objects/TreeNodeToggledEventResult.cs
@@ -14,8 +14,8 @@ namespace SiemensIXBlazor.Objects
     public class TreeNodeToggledEventResult
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
-        [JsonProperty("isExpaned")]
-        public bool IsExpaned { get; set; }
+        public string Id { get; set; } = string.Empty;
+        [JsonProperty("isExpanded")]
+        public bool IsExpanded { get; set; }
     }
 }

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/treeInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/treeInterop.js
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // SPDX-FileCopyrightText: 2024 Siemens AG
 //
 // SPDX-License-Identifier: MIT
@@ -7,78 +7,85 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-
 function getElementOrThrow(id) {
-  const el = document.getElementById(id);
-  if (!el) throw new Error(`Element with ID ${id} not found`);
-  return el;
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Element with ID ${id} not found`);
+  }
+  return element;
 }
 
 function createElement(tag, props, children = []) {
-  const el = document.createElement(tag);
-  Object.assign(el, props);
-  children.forEach(child => el.appendChild(child));
-  return el;
+  const element = document.createElement(tag);
+  Object.assign(element, props);
+  children.forEach((child) => element.appendChild(child));
+  return element;
 }
 
 export function setTreeModel(id, treeModel) {
-  try {
-    const element = getElementOrThrow(id);
-    element.renderItem = (_, item, __, context, update) => {
-      const { icon: iconName, name: itemName } = item.data || {};
-      const children = [];
+  const element = getElementOrThrow(id);
+  const model = JSON.parse(treeModel);
 
-      if (iconName) {
-        children.push(createElement('ix-icon', {
-          name: iconName,
-          style: 'margin-right: 0.5rem'
-        }));
-      }
+  element.renderItem = (_, item, __, context, update) => {
+    const { icon: iconName, name: itemName } = item.data || {};
+    const children = [];
 
-      let nameEl;
-      if (itemName) {
-        nameEl = createElement('span', { innerText: itemName });
-        children.push(nameEl);
-      }
+    if (iconName) {
+      children.push(createElement('ix-icon', {
+        name: iconName,
+        style: 'margin-right: 0.5rem',
+      }));
+    }
 
-      const el = createElement('ix-tree-item', {
-        hasChildren: item.hasChildren,
-        context: context[item.id]
-      }, children);
+    const itemContext = context[item.id];
+    const treeItem = createElement('ix-tree-item', {
+      text: itemName,
+      hasChildren: item.hasChildren,
+      context: itemContext,
+      disabled: Boolean(item.disabled || itemContext?.isDisabled),
+    }, children);
 
-      update(updateTreeItem => {
-        const uData = updateTreeItem.data || {};
-        if (nameEl && uData.name) nameEl.innerText = uData.name;
-      });
+    update((updatedItem) => {
+      treeItem.text = updatedItem.data?.name;
+      treeItem.disabled = Boolean(updatedItem.disabled);
+    });
 
-      return el;
-    };
-    element.model = JSON.parse(treeModel);
-  } catch (error) {
-    console.error('Failed to set tree model:', error);
-  }
+    return treeItem;
+  };
+
+  element.model = model;
 }
 
 export function setTreeContext(id, treeContext) {
-  try {
-    const element = getElementOrThrow(id);
-    element.context = JSON.parse(treeContext);
-  } catch (error) {
-    console.error('Failed to set tree context:', error);
+  const element = getElementOrThrow(id);
+  element.context = JSON.parse(treeContext);
+}
+
+export function setToggleOnItemClick(id, value) {
+  const element = getElementOrThrow(id);
+  element.toggleOnItemClick = value;
+}
+
+export function setTreeItemContext(id, context) {
+  const element = getElementOrThrow(id);
+  element.context = context ? JSON.parse(context) : undefined;
+}
+
+export function setTreeItemProperty(id, propertyName, propertyValue) {
+  const element = getElementOrThrow(id);
+  element[propertyName] = propertyValue;
+}
+
+export async function refreshTree(id, options = { force: false }) {
+  const element = getElementOrThrow(id);
+  if (typeof element.refreshTree === 'function') {
+    await element.refreshTree(options);
   }
 }
 
-export function markItemAsDirty(treeId, itemIdentifiers) {
-  console.log('markItemAsDirty called:', treeId, itemIdentifiers);
-  const treeElement = document.getElementById(treeId);
-  if (!treeElement) {
-    console.warn(`Tree element with id '${treeId}' not found`);
-    return;
-  }
-  if (typeof treeElement.markItemsAsDirty === 'function') {
-    treeElement.markItemsAsDirty(itemIdentifiers);
-    console.log('Items marked as dirty:', itemIdentifiers);
-  } else {
-    console.warn('markItemsAsDirty method not available on tree element');
+export async function markItemsAsDirty(id, itemIdentifiers) {
+  const element = document.getElementById(id);
+  if (element && typeof element.markItemsAsDirty === 'function') {
+    await element.markItemsAsDirty(itemIdentifiers);
   }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

The Tree wrapper is missing the public TreeItem component and several official Tree behaviors, including item-click toggling, refresh options, disabled context state, and the correctly named toggle event payload property.

GitHub Issue Number: #257

## 🆕 What is the new behavior?

- Add the public TreeItem wrapper with official properties, slots, and events.
- Add item-click toggling, forced refresh support, disabled tree state, and corrected event payloads.
- Update tests, README examples, and the Tree verification demo.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)