### PR TITLE
feat(application): align application and header with IX v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ Add `Theme` component to the page that you want to manipulate the theme.
 ```razor
 <Theme @ref="themeProvider"></Theme>
 
-<Button ClickEvent="SetDarkTheme">Set Dark Theme</Button>
+<Button ClickEvent="SetClassicTheme">Set Classic Theme</Button>
 <Button ClickEvent="ToggleTheme">Toggle Theme</Button>
-<Button ClickEvent="ToggleSystemTheme">Toggle System Theme</Button>
 ```
 
 Then use this methods to change theme.
@@ -77,7 +76,7 @@ public partial class Index
     {
         if(firstRender)
         {
-            await themeProvider.SetTheme("theme-classic-light");
+            await themeProvider.SetTheme("classic");
         }
 
     }
@@ -87,17 +86,16 @@ public partial class Index
         await themeProvider.ToggleTheme();
     }
 
-    private async Task SetDarkTheme()
+    private async Task SetClassicTheme()
     {
-        await themeProvider.SetTheme("theme-classic-dark");
-    }
-
-    private async Task ToggleSystemTheme()
-    {
-        await themeProvider.ToggleSystemTheme(true);
+        await themeProvider.SetTheme("classic");
     }
 }
 ```
+
+In iX v5, the theme name and color schema are separate. Use a theme name such as
+`classic` together with `Application.ColorSchema` (`Light`, `Dark`, or `System`).
+Do not use the legacy `theme-classic-light` or `theme-classic-dark` values.
 
 ### Supported Components
 
@@ -173,9 +171,16 @@ public partial class Index
 ## Application
 
 ```razor
-<Application @ref="_app">
-    <ApplicationHeader Name="My Application">
-        <placeholder-logo slot="logo"></placeholder-logo>
+<Application Id="application" @ref="_app" Theme="classic" ColorSchema="System">
+    <ApplicationHeader Id="application-header" Name="My Application">
+        <Logo>
+            <placeholder-logo></placeholder-logo>
+        </Logo>
+        <Button Variant="tertiary">Header action</Button>
+        <ix-avatar slot="ix-application-header-avatar"
+                   initials="JD"
+                   username="Jane Doe"
+                   extra="Product Engineering"></ix-avatar>
     </ApplicationHeader>
     <Menu>
         <MenuItem>Item 1</MenuItem>
@@ -225,8 +230,10 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
 ## Application Header
 
 ```razor
-<ApplicationHeader Name="My Application">
-    <placeholder-logo slot="logo"></placeholder-logo>
+<ApplicationHeader Id="application-header" Name="My Application">
+    <Logo>
+        <placeholder-logo></placeholder-logo>
+    </Logo>
 </ApplicationHeader>
 ```
 

--- a/SiemensIXBlazor.Tests/ApplicationHeaderTests.cs
+++ b/SiemensIXBlazor.Tests/ApplicationHeaderTests.cs
@@ -26,11 +26,15 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.CompanyLogoAlt, "Company Logo");
                 parameters.Add(p => p.AppIcon, "app-icon.svg");
                 parameters.Add(p => p.AppIconAlt, "App Icon");
+                parameters.Add(p => p.AppIconOutline, true);
                 parameters.Add(p => p.HideBottomBorder, true);
+                parameters.Add(p => p.ShowMenu, true);
+                parameters.Add(p => p.AriaLabelAppSwitchIconButton, "Open applications");
+                parameters.Add(p => p.AriaLabelMoreMenuIconButton, "More actions");
             });
 
             // Assert
-            cut.MarkupMatches("<ix-application-header id='' name='testName' name-suffix='testSuffix' company-logo='logo.png' company-logo-alt='Company Logo' app-icon='app-icon.svg' app-icon-alt='App Icon' hide-bottom-border=\"\" ></ix-application-header>");
+            cut.MarkupMatches("<ix-application-header id='' name='testName' name-suffix='testSuffix' company-logo='logo.png' company-logo-alt='Company Logo' app-icon='app-icon.svg' app-icon-alt='App Icon' app-icon-outline='' hide-bottom-border='' show-menu='' aria-label-app-switch-icon-button='Open applications' aria-label-more-menu-icon-button='More actions' slot='application-header'></ix-application-header>");
         }
 
         [Fact]
@@ -70,6 +74,19 @@ namespace SiemensIXBlazor.Tests
         }
 
         [Fact]
+        public void ApplicationHeaderRendersNamedSlots()
+        {
+            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+                .Add(p => p.Overflow, builder => builder.AddContent(0, "Overflow"))
+                .Add(p => p.Logo, builder => builder.AddContent(1, "Logo"))
+                .Add(p => p.Avatar, builder => builder.AddContent(2, "Avatar")));
+
+            Assert.Contains("slot=\"overflow\"", cut.Markup);
+            Assert.Contains("slot=\"logo\"", cut.Markup);
+            Assert.Contains("slot=\"ix-application-header-avatar\"", cut.Markup);
+        }
+
+        [Fact]
         public void ApplicationHeaderDoesNotRenderSecondarySlotWhenNull()
         {
             // Arrange & Act
@@ -95,6 +112,20 @@ namespace SiemensIXBlazor.Tests
 
             // Assert
             Assert.True(eventTriggered);
+        }
+
+        [Fact]
+        public async Task MenuToggleEventWorks()
+        {
+            var menuExpanded = false;
+            var cut = RenderComponent<ApplicationHeader>(
+                ("Id", "headerId"),
+                ("MenuToggleEvent", EventCallback.Factory.Create<bool>(this, value => menuExpanded = value))
+            );
+
+            await cut.InvokeAsync(() => cut.Instance.MenuToggle(true));
+
+            Assert.True(menuExpanded);
         }
 
         [Fact]

--- a/SiemensIXBlazor.Tests/ApplicationTests.cs
+++ b/SiemensIXBlazor.Tests/ApplicationTests.cs
@@ -23,22 +23,32 @@ namespace SiemensIXBlazor.Tests
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.ForceBreakpoint, Enums.ForceBreakpoint.lg);
                 parameters.Add(p => p.Theme, "testTheme");
-                parameters.Add(p => p.ThemeSystemAppearance, true);
+                parameters.Add(p => p.ColorSchema, Enums.ColorSchema.Dark);
             });
 
             // Assert
-            cut.MarkupMatches("<ix-application id='testId' force-breakpoint='lg' theme='testTheme' theme-system-appearance=''></ix-application>");
+            cut.MarkupMatches("<ix-application id='testId' force-breakpoint='lg' theme='testTheme' color-schema='dark'></ix-application>");
+        }
+
+        [Fact]
+        public void ColorSchemaDefaultsToSystem()
+        {
+            var cut = RenderComponent<Application>();
+
+            Assert.Equal(Enums.ColorSchema.System, cut.Instance.ColorSchema);
+            Assert.Contains("color-schema=\"system\"", cut.Markup);
         }
 
         [Fact]
         public void AppSwitchConfig_SetsValueAndCallsInitialParameter()
         {
             // Arrange
-            var cut = RenderComponent<Application>();
-            var config = new AppSwitchConfig();
-
-            // Act
-            cut.Instance.AppSwitchConfig = config;
+            var config = new AppSwitchConfig
+            {
+                CurrentAppId = "app-1"
+            };
+            var cut = RenderComponent<Application>(parameters => parameters
+                .Add(p => p.AppSwitchConfig, config));
 
             // Assert
             Assert.Equal(config, cut.Instance.AppSwitchConfig);

--- a/SiemensIXBlazor/Components/Application/Application.razor
+++ b/SiemensIXBlazor/Components/Application/Application.razor
@@ -11,13 +11,14 @@
 @namespace SiemensIXBlazor.Components
 @inherits IXBaseComponent
 @using Microsoft.JSInterop
-@using System.Text.Json
+@using SiemensIXBlazor.Enums
+@using SiemensIXBlazor.Helpers
 @inject IJSRuntime JSRuntime
 
 <ix-application class="@Class" style="@Style" @attributes="UserAttributes" 
     id="@Id" 
     force-breakpoint="@ForceBreakpoint" 
     theme="@Theme" 
-    theme-system-appearance="@ThemeSystemAppearance">
+    color-schema="@(EnumParser<ColorSchema>.EnumToString(ColorSchema))">
   @ChildContent
 </ix-application>

--- a/SiemensIXBlazor/Components/Application/Application.razor.cs
+++ b/SiemensIXBlazor/Components/Application/Application.razor.cs
@@ -14,34 +14,60 @@ using Microsoft.JSInterop;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using SiemensIXBlazor.Enums;
-using SiemensIXBlazor.Interops;
 using SiemensIXBlazor.Objects.Application;
 
 public partial class Application 
 {
     private Lazy<Task<IJSObjectReference>>? moduleTask;
-    private BaseInterop? _interop;
-    private AppSwitchConfig _appSwitchConfig;
+    private AppSwitchConfig? _appSwitchConfig;
+    private bool _hasRendered;
+    private int _appSwitchConfigVersion;
+    private int _appliedAppSwitchConfigVersion;
+    private string[] _breakpoints = ["sm", "md", "lg"];
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
     [Parameter, EditorRequired]
     public string Id { get; set; } = string.Empty;
     [Parameter]
-    public string[] Breakpoints { get; set; } = ["sm", "md", "lg"];
+    public string[] Breakpoints
+    {
+        get => _breakpoints;
+        set
+        {
+            _breakpoints = value ?? [];
+
+            if (_hasRendered)
+            {
+                _ = ApplyBreakpointsAsync(_breakpoints);
+            }
+        }
+    }
     [Parameter]
     public ForceBreakpoint? ForceBreakpoint { get; set; }
     [Parameter]
     public string? Theme { get; set; }
     [Parameter]
-    public bool ThemeSystemAppearance { get; set; } = false;
-    public AppSwitchConfig AppSwitchConfig
+    public ColorSchema ColorSchema { get; set; } = ColorSchema.System;
+
+    [Parameter]
+    public AppSwitchConfig? AppSwitchConfig
     {
         get => _appSwitchConfig;
         set
         {
+            if (ReferenceEquals(_appSwitchConfig, value))
+            {
+                return;
+            }
+
             _appSwitchConfig = value;
-            InitialParameter("setApplicationConfig", _appSwitchConfig);
+            _appSwitchConfigVersion++;
+
+            if (_hasRendered)
+            {
+                _ = ApplyApplicationConfigAsync(_appSwitchConfigVersion, value);
+            }
         }
     }
 
@@ -53,29 +79,56 @@ public partial class Application
                 "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/applicationInterop.js").AsTask());
 
             var module = await moduleTask.Value;
-            if (module != null)
+            await module.InvokeVoidAsync("setBreakpoints", Id, _breakpoints);
+            _hasRendered = true;
+
+            if (_appliedAppSwitchConfigVersion != _appSwitchConfigVersion)
             {
-                await module.InvokeVoidAsync("setBreakpoints", Id, Breakpoints);
+                await ApplyApplicationConfigAsync(_appSwitchConfigVersion, _appSwitchConfig);
             }
         }
     }
 
-    private void InitialParameter(string functionName, object param)
+    private async Task ApplyBreakpointsAsync(string[] breakpoints)
     {
-
-        moduleTask = new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/applicationInterop.js").AsTask());
-
-        Task.Run(async () =>
+        try
         {
+            moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/applicationInterop.js").AsTask());
+
             var module = await moduleTask.Value;
-            if (module != null)
+            await module.InvokeVoidAsync("setBreakpoints", Id, breakpoints);
+        }
+        catch (JSDisconnectedException)
+        {
+            // The component can be disposed while the module is loading.
+        }
+    }
+
+    private async Task ApplyApplicationConfigAsync(int version, AppSwitchConfig? config)
+    {
+        try
+        {
+            moduleTask ??= new(() => JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/applicationInterop.js").AsTask());
+
+            var module = await moduleTask.Value;
+            if (version != _appSwitchConfigVersion)
             {
-                await module.InvokeVoidAsync(functionName, Id, JsonConvert.SerializeObject(param, new JsonSerializerSettings
+                return;
+            }
+
+            await module.InvokeVoidAsync("setApplicationConfig", Id,
+                JsonConvert.SerializeObject(config, new JsonSerializerSettings
                 {
                     ContractResolver = new CamelCasePropertyNamesContractResolver()
                 }));
-            }
-        });
+
+            _appliedAppSwitchConfigVersion = version;
+        }
+        catch (JSDisconnectedException)
+        {
+            // The component can be disposed while the module is loading.
+        }
     }
 }

--- a/SiemensIXBlazor/Components/ApplicationHeader/ApplicationHeader.razor
+++ b/SiemensIXBlazor/Components/ApplicationHeader/ApplicationHeader.razor
@@ -21,13 +21,36 @@
                       company-logo-alt="@CompanyLogoAlt"
                       app-icon="@AppIcon"
                       app-icon-alt="@AppIconAlt"
+                      app-icon-outline="@AppIconOutline"
                       hide-bottom-border="@HideBottomBorder"
-                      enable-top-layer="@EnableTopLayer">
+                      show-menu="@ShowMenu"
+                      aria-label-app-switch-icon-button="@AriaLabelAppSwitchIconButton"
+                      aria-label-more-menu-icon-button="@AriaLabelMoreMenuIconButton"
+                      enable-top-layer="@EnableTopLayer"
+                      slot="application-header">
     @ChildContent
     @if (Secondary != null)
     {
         <div slot="secondary">
             @Secondary
+        </div>
+    }
+    @if (Overflow != null)
+    {
+        <div slot="overflow">
+            @Overflow
+        </div>
+    }
+    @if (Logo != null)
+    {
+        <div slot="logo">
+            @Logo
+        </div>
+    }
+    @if (Avatar != null)
+    {
+        <div slot="ix-application-header-avatar">
+            @Avatar
         </div>
     }
 </ix-application-header>

--- a/SiemensIXBlazor/Components/ApplicationHeader/ApplicationHeader.razor.cs
+++ b/SiemensIXBlazor/Components/ApplicationHeader/ApplicationHeader.razor.cs
@@ -26,6 +26,15 @@ namespace SiemensIXBlazor.Components
         public RenderFragment? Secondary { get; set; }
 
         [Parameter]
+        public RenderFragment? Overflow { get; set; }
+
+        [Parameter]
+        public RenderFragment? Logo { get; set; }
+
+        [Parameter]
+        public RenderFragment? Avatar { get; set; }
+
+        [Parameter]
         public string? Name { get; set; }
 
         [Parameter]
@@ -44,7 +53,19 @@ namespace SiemensIXBlazor.Components
         public string? AppIconAlt { get; set; }
 
         [Parameter]
+        public bool AppIconOutline { get; set; } = false;
+
+        [Parameter]
         public bool HideBottomBorder { get; set; } = false;
+
+        [Parameter]
+        public bool ShowMenu { get; set; } = false;
+
+        [Parameter]
+        public string? AriaLabelAppSwitchIconButton { get; set; }
+
+        [Parameter]
+        public string? AriaLabelMoreMenuIconButton { get; set; }
 
         [Parameter]
         public bool EnableTopLayer { get; set; } = false;
@@ -55,6 +76,9 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public EventCallback OpenAppSwitchEvent { get; set; }
 
+        [Parameter]
+        public EventCallback<bool> MenuToggleEvent { get; set; }
+
 
 
         protected async override Task OnAfterRenderAsync(bool firstRender)
@@ -64,6 +88,7 @@ namespace SiemensIXBlazor.Components
                 _interop = new(JSRuntime);
 
                 await _interop.AddEventListener(this, Id, "openAppSwitch", "OpenAppSwitch");
+                await _interop.AddEventListener(this, Id, "menuToggle", "MenuToggle");
             }
         }
 
@@ -71,6 +96,12 @@ namespace SiemensIXBlazor.Components
         public async Task OpenAppSwitch()
         {
             await OpenAppSwitchEvent.InvokeAsync();
+        }
+
+        [JSInvokable]
+        public async Task MenuToggle(bool expanded)
+        {
+            await MenuToggleEvent.InvokeAsync(expanded);
         }
 }
 }

--- a/SiemensIXBlazor/Enums/Application/ColorSchemaEnum.cs
+++ b/SiemensIXBlazor/Enums/Application/ColorSchemaEnum.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// SPDX-FileCopyrightText: 2026 Siemens AG
+//
+// SPDX-License-Identifier: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//  -----------------------------------------------------------------------
+
+namespace SiemensIXBlazor.Enums;
+
+public enum ColorSchema
+{
+    Light,
+    Dark,
+    System
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

Application exposed the obsolete `ThemeSystemAppearance` property and did not fully support the official Application configuration API.

ApplicationHeader was missing several official properties, accessibility labels, the typed menu toggle callback, and named public slots.

GitHub Issue Number: #251

## 🆕 What is the new behavior?

- Add typed `ColorSchema`, application configuration, and breakpoint updates.
- Add ApplicationHeader `app-icon outline`, `menu visibility`, `accessibility labels`, typed `menu toggle events`, and official slots.
- Update tests and README examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)