### PR TITLE
chore(test): upgrade bUnit to 2.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageVersion Include="bunit" Version="1.40.0" />
+		<PackageVersion Include="bunit" Version="2.9.0" />
 		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/SiemensIXBlazor.Tests/AGGrid/AGGridTests.cs
+++ b/SiemensIXBlazor.Tests/AGGrid/AGGridTests.cs
@@ -23,7 +23,7 @@ namespace SiemensIXBlazor.Tests
         public void ComponentRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<AGGrid>();
+            var cut = Render<AGGrid>((Action<Bunit.ComponentParameterCollectionBuilder<AGGrid>>)(_ => { }));
 
             // Assert
             cut.MarkupMatches("<div id=''></div>");
@@ -34,7 +34,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var eventTriggered = false;
-            var cut = RenderComponent<AGGrid>(parameters => parameters.Add(p => p.OnCellClicked, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+            var cut = Render<AGGrid>(parameters => parameters.Add(p => p.OnCellClicked, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
             // Act
             cut.Instance.OnCellClicked.InvokeAsync(true);
@@ -47,7 +47,7 @@ namespace SiemensIXBlazor.Tests
         public void IdPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
+            var cut = Render<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
 
             // Assert
             Assert.Equal("testId", cut.Instance.Id);
@@ -79,7 +79,7 @@ namespace SiemensIXBlazor.Tests
                 .Returns(new ValueTask<IJSObjectReference>(jsObjectReferenceMock.Object));
             Services.AddSingleton(jsRuntimeMock.Object);
 
-            var cut = RenderComponent<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
+            var cut = Render<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
 
             // Act
             var result = await cut.Instance.CreateGrid(gridOptions);
@@ -95,7 +95,7 @@ namespace SiemensIXBlazor.Tests
             // Arrange
             var jsRuntimeMock = new Mock<IJSRuntime>();
             Services.AddSingleton(jsRuntimeMock.Object);
-            var cut = RenderComponent<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
+            var cut = Render<AGGrid>(parameters => parameters.Add(p => p.Id, "testId"));
             var jsObjectReferenceMock = new Mock<IJSObjectReference>();
             jsRuntimeMock.Setup(x => x.InvokeAsync<object>("siemensIXInterop.agGridInterop.getSelectedRows", It.IsAny<object[]>()))
                 .ReturnsAsync(new object());

--- a/SiemensIXBlazor.Tests/ActionCardTests.cs
+++ b/SiemensIXBlazor.Tests/ActionCardTests.cs
@@ -19,7 +19,7 @@ namespace SiemensIXBlazor.Tests
         public void ComponentRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>();
+            var cut = Render<ActionCard>((Action<Bunit.ComponentParameterCollectionBuilder<ActionCard>>)(_ => { }));
 
             // Assert
             cut.MarkupMatches("<ix-action-card variant='outline'></ix-action-card>");
@@ -29,7 +29,7 @@ namespace SiemensIXBlazor.Tests
         public void IconPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Icon, "testIcon"));
+            var cut = Render<ActionCard>(parameters => parameters.Add(p => p.Icon, "testIcon"));
 
             // Assert
             Assert.Equal("testIcon", cut.Instance.Icon);
@@ -39,7 +39,7 @@ namespace SiemensIXBlazor.Tests
         public void HeadingPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Heading, "testHeading"));
+            var cut = Render<ActionCard>(parameters => parameters.Add(p => p.Heading, "testHeading"));
 
             // Assert
             Assert.Equal("testHeading", cut.Instance.Heading);
@@ -49,7 +49,7 @@ namespace SiemensIXBlazor.Tests
         public void SubHeadingPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.SubHeading, "testSubHeading"));
+            var cut = Render<ActionCard>(parameters => parameters.Add(p => p.SubHeading, "testSubHeading"));
 
             // Assert
             Assert.Equal("testSubHeading", cut.Instance.SubHeading);
@@ -59,7 +59,7 @@ namespace SiemensIXBlazor.Tests
         public void SelectedPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Selected, true));
+            var cut = Render<ActionCard>(parameters => parameters.Add(p => p.Selected, true));
 
             // Assert
             Assert.True(cut.Instance.Selected);
@@ -70,7 +70,7 @@ namespace SiemensIXBlazor.Tests
         public void VariantPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters.Add(p => p.Variant, ActionCardVariant.outline));
+            var cut = Render<ActionCard>(parameters => parameters.Add(p => p.Variant, ActionCardVariant.outline));
 
             // Assert
             Assert.Equal(ActionCardVariant.outline, cut.Instance.Variant);
@@ -80,7 +80,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>();
+            var cut = Render<ActionCard>((Action<Bunit.ComponentParameterCollectionBuilder<ActionCard>>)(_ => { }));
 
             // Assert
             Assert.False(cut.Instance.Passive);
@@ -91,7 +91,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<ActionCard>(parameters => parameters
+            var cut = Render<ActionCard>(parameters => parameters
                 .Add(p => p.Passive, true));
 
             // Assert
@@ -102,7 +102,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void RendersDefaultContent()
         {
-            var cut = RenderComponent<ActionCard>(parameters => parameters
+            var cut = Render<ActionCard>(parameters => parameters
                 .Add(p => p.ChildContent, builder => builder.AddContent(0, "Additional content")));
 
             Assert.Contains("Additional content", cut.Markup);

--- a/SiemensIXBlazor.Tests/ApplicationHeaderTests.cs
+++ b/SiemensIXBlazor.Tests/ApplicationHeaderTests.cs
@@ -19,7 +19,7 @@ namespace SiemensIXBlazor.Tests
         public void ApplicationHeaderRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<ApplicationHeader>(parameters => {
+            var cut = Render<ApplicationHeader>(parameters => {
                 parameters.Add(p => p.Name, "testName");
                 parameters.Add(p => p.NameSuffix, "testSuffix");
                 parameters.Add(p => p.CompanyLogo, "logo.png");
@@ -44,7 +44,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+            var cut = Render<ApplicationHeader>(parameters => parameters
                 .Add(p => p.ChildContent, builder => 
                 {
                     builder.AddContent(0, expectedContent);
@@ -61,7 +61,7 @@ namespace SiemensIXBlazor.Tests
             var expectedSecondaryContent = "Secondary content";
 
             // Act
-            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+            var cut = Render<ApplicationHeader>(parameters => parameters
                 .Add(p => p.Secondary, builder => 
                 {
                     builder.AddContent(0, expectedSecondaryContent);
@@ -76,7 +76,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void ApplicationHeaderRendersNamedSlots()
         {
-            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+            var cut = Render<ApplicationHeader>(parameters => parameters
                 .Add(p => p.Overflow, builder => builder.AddContent(0, "Overflow"))
                 .Add(p => p.Logo, builder => builder.AddContent(1, "Logo"))
                 .Add(p => p.Avatar, builder => builder.AddContent(2, "Avatar")));
@@ -90,7 +90,7 @@ namespace SiemensIXBlazor.Tests
         public void ApplicationHeaderDoesNotRenderSecondarySlotWhenNull()
         {
             // Arrange & Act
-            var cut = RenderComponent<ApplicationHeader>(parameters => {
+            var cut = Render<ApplicationHeader>(parameters => {
                 parameters.Add(p => p.Name, "testName");
             });
 
@@ -102,9 +102,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var eventTriggered = false;
-            var cut = RenderComponent<ApplicationHeader>(
-                ("Id", "headerId"),
-                ("OpenAppSwitchEvent", EventCallback.Factory.Create(this, () => { eventTriggered = true; }))
+            var cut = Render<ApplicationHeader>(parameters => parameters
+                .Add(p => p.Id, "headerId")
+                .Add(p => p.OpenAppSwitchEvent, EventCallback.Factory.Create(this, () => { eventTriggered = true; }))
             );
 
             // Act
@@ -118,9 +118,9 @@ namespace SiemensIXBlazor.Tests
         public async Task MenuToggleEventWorks()
         {
             var menuExpanded = false;
-            var cut = RenderComponent<ApplicationHeader>(
-                ("Id", "headerId"),
-                ("MenuToggleEvent", EventCallback.Factory.Create<bool>(this, value => menuExpanded = value))
+            var cut = Render<ApplicationHeader>(parameters => parameters
+                .Add(p => p.Id, "headerId")
+                .Add(p => p.MenuToggleEvent, EventCallback.Factory.Create<bool>(this, value => menuExpanded = value))
             );
 
             await cut.InvokeAsync(() => cut.Instance.MenuToggle(true));
@@ -132,7 +132,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+            var cut = Render<ApplicationHeader>(parameters => parameters
                 .Add(p => p.Id, "test-id"));
 
             // Assert
@@ -144,7 +144,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<ApplicationHeader>(parameters => parameters
+            var cut = Render<ApplicationHeader>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.EnableTopLayer, true));
 

--- a/SiemensIXBlazor.Tests/ApplicationTests.cs
+++ b/SiemensIXBlazor.Tests/ApplicationTests.cs
@@ -19,7 +19,7 @@ namespace SiemensIXBlazor.Tests
         public void ApplicationRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Application>(parameters => {
+            var cut = Render<Application>(parameters => {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.ForceBreakpoint, Enums.ForceBreakpoint.lg);
                 parameters.Add(p => p.Theme, "testTheme");
@@ -33,7 +33,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void ColorSchemaDefaultsToSystem()
         {
-            var cut = RenderComponent<Application>();
+            var cut = Render<Application>((Action<Bunit.ComponentParameterCollectionBuilder<Application>>)(_ => { }));
 
             Assert.Equal(Enums.ColorSchema.System, cut.Instance.ColorSchema);
             Assert.Contains("color-schema=\"system\"", cut.Markup);
@@ -47,7 +47,7 @@ namespace SiemensIXBlazor.Tests
             {
                 CurrentAppId = "app-1"
             };
-            var cut = RenderComponent<Application>(parameters => parameters
+            var cut = Render<Application>(parameters => parameters
                 .Add(p => p.AppSwitchConfig, config));
 
             // Assert

--- a/SiemensIXBlazor.Tests/AvatarTests.cs
+++ b/SiemensIXBlazor.Tests/AvatarTests.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Tests
         public void AvatarRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Avatar>(parameters => {
+            var cut = Render<Avatar>(parameters => {
                 parameters.Add(p => p.Image, "testImage");
                 parameters.Add(p => p.TooltipText, "testTooltipText");
                 parameters.Add(p => p.Initials, "testInitials");
@@ -34,7 +34,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void TooltipTextIsRenderedWithoutChangingOtherAvatarOptions()
         {
-            var cut = RenderComponent<Avatar>(parameters => parameters
+            var cut = Render<Avatar>(parameters => parameters
                 .Add(p => p.Initials, "JD")
                 .Add(p => p.TooltipText, "John Doe"));
 

--- a/SiemensIXBlazor.Tests/BlindTests.cs
+++ b/SiemensIXBlazor.Tests/BlindTests.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void ComponentRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Blind>();
+            var cut = Render<Blind>((Action<Bunit.ComponentParameterCollectionBuilder<Blind>>)(_ => { }));
 
             // Assert
             cut.MarkupMatches("<ix-blind id='' variant='filled'></ix-blind>");
@@ -30,7 +30,7 @@ namespace SiemensIXBlazor.Tests
         public void IdPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Id, "testId"));
+            var cut = Render<Blind>(parameters => parameters.Add(p => p.Id, "testId"));
 
             // Assert
             Assert.Equal("testId", cut.Instance.Id);
@@ -40,7 +40,7 @@ namespace SiemensIXBlazor.Tests
         public void CollapsedPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Collapsed, true));
+            var cut = Render<Blind>(parameters => parameters.Add(p => p.Collapsed, true));
 
             // Assert
             Assert.True(cut.Instance.Collapsed);
@@ -50,7 +50,7 @@ namespace SiemensIXBlazor.Tests
         public void IconPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Icon, "testIcon"));
+            var cut = Render<Blind>(parameters => parameters.Add(p => p.Icon, "testIcon"));
 
             // Assert
             Assert.Equal("testIcon", cut.Instance.Icon);
@@ -60,7 +60,7 @@ namespace SiemensIXBlazor.Tests
         public void VariantPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.Variant, BlindVariant.filled));
+            var cut = Render<Blind>(parameters => parameters.Add(p => p.Variant, BlindVariant.filled));
 
             // Assert
             Assert.Equal(BlindVariant.filled, cut.Instance.Variant);
@@ -69,7 +69,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void BlindRendersCustomHeaderAndHeaderActionsSlots()
         {
-            var cut = RenderComponent<Blind>(parameters => parameters
+            var cut = Render<Blind>(parameters => parameters
                 .Add(p => p.CustomHeader, builder => builder.AddContent(0, "Custom header"))
                 .Add(p => p.HeaderActions, builder => builder.AddContent(0, "Actions"))
                 .Add(p => p.ChildContent, builder => builder.AddContent(0, "Blind content")));
@@ -85,7 +85,7 @@ namespace SiemensIXBlazor.Tests
         public async Task CollapsedChangedEventPassesTypedValue()
         {
             var collapsed = false;
-            var cut = RenderComponent<Blind>(parameters => parameters
+            var cut = Render<Blind>(parameters => parameters
                 .Add(p => p.CollapsedChangedEvent, EventCallback.Factory.Create<bool>(this, value => collapsed = value)));
 
             await cut.Instance.CollapsedChanged(true);
@@ -98,7 +98,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var eventTriggered = false;
-            var cut = RenderComponent<Blind>(parameters => parameters.Add(p => p.CollapsedChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
+            var cut = Render<Blind>(parameters => parameters.Add(p => p.CollapsedChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
 
             // Act
             cut.Instance.CollapsedChangedEvent.InvokeAsync(true);

--- a/SiemensIXBlazor.Tests/Breadcrumb/BreadcrumbItemTests.cs
+++ b/SiemensIXBlazor.Tests/Breadcrumb/BreadcrumbItemTests.cs
@@ -19,7 +19,7 @@ namespace SiemensIXBlazor.Tests
         public void BreadcrumbItemRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<BreadcrumbItem>(parameters => parameters
+            var cut = Render<BreadcrumbItem>(parameters => parameters
                 .Add(p => p.BreadcrumbKey, "test-key"));
 
             // Assert
@@ -30,7 +30,7 @@ namespace SiemensIXBlazor.Tests
         public void AllPropertiesAreSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<BreadcrumbItem>(parameters => parameters
+            var cut = Render<BreadcrumbItem>(parameters => parameters
                 .Add(p => p.BreadcrumbKey, "test-key")
                 .Add(p => p.Icon, "testIcon")
                 .Add(p => p.Label, "testLabel")

--- a/SiemensIXBlazor.Tests/Breadcrumb/BreadcrumbTests.cs
+++ b/SiemensIXBlazor.Tests/Breadcrumb/BreadcrumbTests.cs
@@ -21,7 +21,7 @@ namespace SiemensIXBlazor.Tests
         public void BreadcrumbRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Breadcrumb>(parameters =>
+            var cut = Render<Breadcrumb>(parameters =>
             {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.Subtle, true);
@@ -41,7 +41,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<Breadcrumb>(parameters => parameters
+            var cut = Render<Breadcrumb>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, expectedContent);
@@ -56,7 +56,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             BreadcrumbClick? clickedItem = null;
-            var cut = RenderComponent<Breadcrumb>(parameters => parameters.Add(p => p.ItemClicked, EventCallback.Factory.Create<BreadcrumbClick>(this, item => clickedItem = item)));
+            var cut = Render<Breadcrumb>(parameters => parameters.Add(p => p.ItemClicked, EventCallback.Factory.Create<BreadcrumbClick>(this, item => clickedItem = item)));
 
             // Act
             cut.Instance.BreadcrumbItemClicked(JsonSerializer.SerializeToElement(new { breadcrumbKey = "test-key", label = "test" }));
@@ -71,7 +71,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             BreadcrumbNextClick? clickedItem = null;
-            var cut = RenderComponent<Breadcrumb>(parameters => parameters.Add(p => p.NextItemClicked, EventCallback.Factory.Create<BreadcrumbNextClick>(this, item => clickedItem = item)));
+            var cut = Render<Breadcrumb>(parameters => parameters.Add(p => p.NextItemClicked, EventCallback.Factory.Create<BreadcrumbNextClick>(this, item => clickedItem = item)));
 
             // Act
             cut.Instance.BreadcrumbNextItemClicked(JsonSerializer.SerializeToElement(new { @event = new { type = "click" }, item = new { breadcrumbKey = "test-key", label = "test" } }));
@@ -85,7 +85,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<Breadcrumb>(parameters => parameters
+            var cut = Render<Breadcrumb>(parameters => parameters
                 .Add(p => p.Id, "test-id"));
 
             // Assert
@@ -97,7 +97,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<Breadcrumb>(parameters => parameters
+            var cut = Render<Breadcrumb>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.EnableTopLayer, true));
 

--- a/SiemensIXBlazor.Tests/Button/ButtonTests.cs
+++ b/SiemensIXBlazor.Tests/Button/ButtonTests.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void ButtonRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Button>(parameters => {
+            var cut = Render<Button>(parameters => {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.Variant, ButtonVariant.primary);
                 parameters.Add(p => p.Disabled, true);
@@ -43,7 +43,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var clickInvoked = false;
-            var cut = RenderComponent<Button>(parameters => parameters
+            var cut = Render<Button>(parameters => parameters
                 .Add(p => p.ClickEvent, EventCallback.Factory.Create(this, () => clickInvoked = true)));
 
             // Act

--- a/SiemensIXBlazor.Tests/Button/IconButtonTests.cs
+++ b/SiemensIXBlazor.Tests/Button/IconButtonTests.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void IconButtonRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<IconButton>(parameters => {
+            var cut = Render<IconButton>(parameters => {
                 parameters.Add(p => p.IconColor, "testIconColor");
                 parameters.Add(p => p.Disabled, true);
                 parameters.Add(p => p.Icon, "testIcon");
@@ -40,7 +40,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var clickInvoked = false;
-            var cut = RenderComponent<IconButton>(parameters => parameters
+            var cut = Render<IconButton>(parameters => parameters
                 .Add(p => p.ClickEvent, EventCallback.Factory.Create(this, () => clickInvoked = true)));
 
             // Act

--- a/SiemensIXBlazor.Tests/CardAccordionTests.cs
+++ b/SiemensIXBlazor.Tests/CardAccordionTests.cs
@@ -18,7 +18,7 @@ public class CardAccordionTests : TestContextBase
     [Fact]
     public void RendersOfficialPropertiesAndContent()
     {
-        var cut = RenderComponent<CardAccordion>(parameters => parameters
+        var cut = Render<CardAccordion>(parameters => parameters
             .Add(p => p.AriaLabelExpandButton, "Expand card")
             .Add(p => p.Collapse, true)
             .Add(p => p.Variant, CardAccordionVariant.success)
@@ -30,7 +30,7 @@ public class CardAccordionTests : TestContextBase
     [Fact]
     public void CollapseAndVariantHaveOfficialDefaults()
     {
-        var cut = RenderComponent<CardAccordion>();
+        var cut = Render<CardAccordion>((Action<Bunit.ComponentParameterCollectionBuilder<CardAccordion>>)(_ => { }));
 
         Assert.False(cut.Instance.Collapse);
         Assert.Equal(CardAccordionVariant.outline, cut.Instance.Variant);

--- a/SiemensIXBlazor.Tests/CardListTests.cs
+++ b/SiemensIXBlazor.Tests/CardListTests.cs
@@ -19,7 +19,7 @@ namespace SiemensIXBlazor.Tests
 		public void CardListRendersWithoutCrashing()
 		{
 			// Arrange
-			var cut = RenderComponent<CardList>(parameters =>
+			var cut = Render<CardList>(parameters =>
 			{
 				parameters.Add(p => p.Id, "testId");
 				parameters.Add(p => p.Collapse, true);
@@ -42,7 +42,7 @@ namespace SiemensIXBlazor.Tests
 		{
 			// Arrange
 			var eventTriggered = false;
-			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.CollapseChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
+			var cut = Render<CardList>(parameters => parameters.Add(p => p.CollapseChangedEvent, EventCallback.Factory.Create<bool>(this, () => eventTriggered = true)));
 
 			// Act
 			cut.Instance.CollapseChangedEvent.InvokeAsync(true);
@@ -56,7 +56,7 @@ namespace SiemensIXBlazor.Tests
 		{
 			// Arrange
 			var eventTriggered = false;
-			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowAllClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+			var cut = Render<CardList>(parameters => parameters.Add(p => p.ShowAllClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
 			// Act
 			cut.Instance.ShowAllClickEvent.InvokeAsync();
@@ -70,7 +70,7 @@ namespace SiemensIXBlazor.Tests
 		{
 			// Arrange
 			var eventTriggered = false;
-			var cut = RenderComponent<CardList>(parameters => parameters.Add(p => p.ShowMoreCardClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+			var cut = Render<CardList>(parameters => parameters.Add(p => p.ShowMoreCardClickEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
 			// Act
 			cut.Instance.ShowMoreCardClickEvent.InvokeAsync();

--- a/SiemensIXBlazor.Tests/CardTests.cs
+++ b/SiemensIXBlazor.Tests/CardTests.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Tests
         public void CardRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Card>(parameters =>
+            var cut = Render<Card>(parameters =>
             {
                 parameters.Add(p => p.Selected, true);
                 parameters.Add(p => p.Variant, Enums.CardVariant.neutral);
@@ -35,7 +35,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<Card>(parameters => parameters
+            var cut = Render<Card>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, expectedContent);
@@ -49,7 +49,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<Card>();
+            var cut = Render<Card>((Action<Bunit.ComponentParameterCollectionBuilder<Card>>)(_ => { }));
 
             // Assert
             Assert.False(cut.Instance.Passive);
@@ -60,7 +60,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<Card>(parameters => parameters
+            var cut = Render<Card>(parameters => parameters
                 .Add(p => p.Passive, true));
 
             // Assert
@@ -71,7 +71,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void SelectedDefaultsToFalse()
         {
-            var cut = RenderComponent<Card>();
+            var cut = Render<Card>((Action<Bunit.ComponentParameterCollectionBuilder<Card>>)(_ => { }));
 
             Assert.False(cut.Instance.Selected);
             Assert.DoesNotContain("selected", cut.Markup);

--- a/SiemensIXBlazor.Tests/CardTitleTests.cs
+++ b/SiemensIXBlazor.Tests/CardTitleTests.cs
@@ -17,7 +17,7 @@ public class CardTitleTests : TestContextBase
     [Fact]
     public void RendersDefaultAndTitleActionsSlots()
     {
-        var cut = RenderComponent<CardTitle>(parameters => parameters
+        var cut = Render<CardTitle>(parameters => parameters
             .Add(p => p.ChildContent, builder => builder.AddContent(0, "Title"))
             .Add(p => p.TitleActions, builder => builder.AddContent(0, "Actions")));
 

--- a/SiemensIXBlazor.Tests/CategoryFilterTests.cs
+++ b/SiemensIXBlazor.Tests/CategoryFilterTests.cs
@@ -22,7 +22,7 @@ namespace SiemensIXBlazor.Tests
         public void CategoryFilterRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>(parameters =>
+            var cut = Render<CategoryFilter>(parameters =>
             {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.HideIcon, true);
@@ -44,11 +44,10 @@ namespace SiemensIXBlazor.Tests
         public void CategoriesSetsCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>();
             var mockCategories = new Dictionary<string, Category> { { "category1", new() { Label = "Test Label", Options = ["options1"] } } };
 
-            // Act
-            cut.Instance.Categories = mockCategories;
+            var cut = Render<CategoryFilter>(parameters => parameters
+                .Add(p => p.Categories, mockCategories));
 
             // Assert
             Assert.Equal(cut.Instance.Categories, mockCategories);
@@ -58,11 +57,10 @@ namespace SiemensIXBlazor.Tests
         public void FilterStateSetsCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>();
             var mockFilterState = new FilterState { Categories = [new FilterStateCategory { Id = "testId", Operator = LogicalFilterOperator.NotEqual, Value = "testValue" }] };
 
-            // Act
-            cut.Instance.FilterState = mockFilterState;
+            var cut = Render<CategoryFilter>(parameters => parameters
+                .Add(p => p.FilterState, mockFilterState));
 
             // Assert
             Assert.Equal(cut.Instance.FilterState, mockFilterState);
@@ -72,11 +70,10 @@ namespace SiemensIXBlazor.Tests
         public void NonSelectableCategoriesSetsCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>();
             var mockNonSelectableCategories = new Dictionary<string, string> { { "test", "test" } };
 
-            // Act
-            cut.Instance.NonSelectableCategories = mockNonSelectableCategories;
+            var cut = Render<CategoryFilter>(parameters => parameters
+                .Add(p => p.NonSelectableCategories, mockNonSelectableCategories));
 
             // Assert
             Assert.Equal(cut.Instance.NonSelectableCategories, mockNonSelectableCategories);
@@ -86,11 +83,10 @@ namespace SiemensIXBlazor.Tests
         public void SuggestionsSetsCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>();
             var mockSuggestions = new string[] { "test", "test2" };
 
-            // Act
-            cut.Instance.Suggestions = mockSuggestions;
+            var cut = Render<CategoryFilter>(parameters => parameters
+                .Add(p => p.Suggestions, mockSuggestions));
 
             // Assert
             Assert.Equal(cut.Instance.Suggestions, mockSuggestions);
@@ -100,7 +96,7 @@ namespace SiemensIXBlazor.Tests
         public async Task FilterChangedEventReceivesTypedState()
         {
             FilterState? received = null;
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.FilterChangedEvent, EventCallback.Factory.Create<FilterState>(this, state => received = state)));
 
             var payload = JsonDocument.Parse("""
@@ -116,7 +112,7 @@ namespace SiemensIXBlazor.Tests
         public async Task InputChangedEventReceivesTypedState()
         {
             InputState? received = null;
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.InputChangedEvent, EventCallback.Factory.Create<InputState>(this, state => received = state)));
 
             var payload = JsonDocument.Parse("""{"token":"Sie","category":"vendor"}""").RootElement;
@@ -132,7 +128,7 @@ namespace SiemensIXBlazor.Tests
         {
             string? category = "not-set";
             var cleared = false;
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.CategoryChangedEvent, EventCallback.Factory.Create<string?>(this, value => category = value))
                 .Add(p => p.FilterClearedEvent, EventCallback.Factory.Create<FilterClearedEventArgs>(this, _ => cleared = true)));
 
@@ -148,7 +144,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public async Task FilterClearedCanBeCanceled()
         {
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.FilterClearedEvent, EventCallback.Factory.Create<FilterClearedEventArgs>(this, eventArgs => eventArgs.Cancel = true)));
 
             Assert.True(await cut.Instance.FilterCleared());
@@ -172,12 +168,12 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void RepeatedEquivalentStateDoesNotCauseRecursiveRendering()
         {
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.Id, "category-filter"));
 
             for (var index = 0; index < 100; index++)
             {
-                cut.SetParametersAndRender(parameters => parameters
+                cut.Render(parameters => parameters
                     .Add(p => p.Categories, new Dictionary<string, Category>
                     {
                         ["vendor"] = new() { Label = "Vendor", Options = ["Siemens"] }
@@ -201,7 +197,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.Id, "test-id"));
 
             // Assert
@@ -213,7 +209,7 @@ namespace SiemensIXBlazor.Tests
         public void EnableTopLayerTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<CategoryFilter>(parameters => parameters
+            var cut = Render<CategoryFilter>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.EnableTopLayer, true));
 

--- a/SiemensIXBlazor.Tests/CheckboxTests.cs
+++ b/SiemensIXBlazor.Tests/CheckboxTests.cs
@@ -18,7 +18,7 @@ public class CheckboxTests : TestContextBase
     [Fact]
     public void CheckboxRendersOfficialProperties()
     {
-        var cut = RenderComponent<Checkbox>(parameters => parameters
+        var cut = Render<Checkbox>(parameters => parameters
             .Add(p => p.Id, "checkbox")
             .Add(p => p.Label, "Accept terms")
             .Add(p => p.Name, "terms")
@@ -33,7 +33,7 @@ public class CheckboxTests : TestContextBase
     [Fact]
     public void CheckboxGroupRendersValidationTextAndDirection()
     {
-        var cut = RenderComponent<CheckboxGroup>(parameters => parameters
+        var cut = Render<CheckboxGroup>(parameters => parameters
             .Add(p => p.Id, "checkbox-group")
             .Add(p => p.Label, "Options")
             .Add(p => p.HelperText, "Choose any")
@@ -51,7 +51,9 @@ public class CheckboxTests : TestContextBase
     [Fact]
     public void CheckboxGroupDirectionDefaultsToColumn()
     {
-        var cut = RenderComponent<CheckboxGroup>(("Id", "checkbox-group"));
+        var cut = Render<CheckboxGroup>(parameters => parameters
+            .Add(p => p.Id, "checkbox-group")
+        );
 
         Assert.Equal(CheckboxGroupDirection.Column, cut.Instance.Direction);
         Assert.Equal("column", cut.Find("ix-checkbox-group").GetAttribute("direction"));

--- a/SiemensIXBlazor.Tests/ChipTests.cs
+++ b/SiemensIXBlazor.Tests/ChipTests.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Tests
         public void ChipRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<Chip>(parameters =>
+            var cut = Render<Chip>(parameters =>
             {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.Inactive, true);
@@ -43,7 +43,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<Chip>(parameters => parameters
+            var cut = Render<Chip>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, expectedContent);
@@ -57,7 +57,7 @@ namespace SiemensIXBlazor.Tests
         public void ChipWithCenterContentTrue()
         {
             // Arrange
-            var cut = RenderComponent<Chip>(parameters =>
+            var cut = Render<Chip>(parameters =>
             {
                 parameters.Add(p => p.Id, "centeredChip");
                 parameters.Add(p => p.CenterContent, true);
@@ -71,7 +71,7 @@ namespace SiemensIXBlazor.Tests
         public void ChipWithCenterContentFalse()
         {
             // Arrange
-            var cut = RenderComponent<Chip>(parameters =>
+            var cut = Render<Chip>(parameters =>
             {
                 parameters.Add(p => p.Id, "notCenteredChip");
                 parameters.Add(p => p.CenterContent, false);
@@ -84,7 +84,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void ChipMapsIconAccessibilityAndBooleanTooltip()
         {
-            var cut = RenderComponent<Chip>(parameters => parameters
+            var cut = Render<Chip>(parameters => parameters
                 .Add(p => p.Id, "accessibleChip")
                 .Add(p => p.Icon, "info")
                 .Add(p => p.AriaLabelIcon, "Information")
@@ -101,7 +101,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void ChipFalseTooltipDoesNotRenderTooltipAttribute()
         {
-            var cut = RenderComponent<Chip>(parameters => parameters
+            var cut = Render<Chip>(parameters => parameters
                 .Add(p => p.Id, "noTooltipChip")
                 .Add(p => p.TooltipText, false));
 

--- a/SiemensIXBlazor.Tests/ContentHeaderTests.cs
+++ b/SiemensIXBlazor.Tests/ContentHeaderTests.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void ContentHeaderRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<ContentHeader>(parameters => {
+            var cut = Render<ContentHeader>(parameters => {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.HasBackButton, true);
                 parameters.Add(p => p.HeaderSubTitle, "testHeaderSubTitle");
@@ -39,7 +39,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<ContentHeader>(parameters => parameters
+            var cut = Render<ContentHeader>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, expectedContent);
@@ -56,7 +56,7 @@ namespace SiemensIXBlazor.Tests
             var expectedHeaderContent = "Header content";
 
             // Act
-            var cut = RenderComponent<ContentHeader>(parameters => parameters
+            var cut = Render<ContentHeader>(parameters => parameters
                 .Add(p => p.HeaderContent, builder =>
                 {
                     builder.AddContent(0, expectedHeaderContent);
@@ -71,7 +71,7 @@ namespace SiemensIXBlazor.Tests
         public void ContentHeaderDoesNotRenderHeaderSlotWhenNull()
         {
             // Arrange & Act
-            var cut = RenderComponent<ContentHeader>();
+            var cut = Render<ContentHeader>((Action<Bunit.ComponentParameterCollectionBuilder<ContentHeader>>)(_ => { }));
 
             // Assert
             Assert.DoesNotContain("slot=\"header\"", cut.Markup);
@@ -82,7 +82,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var eventTriggered = false;
-            var cut = RenderComponent<ContentHeader>(parameters => parameters.Add(p => p.BackButtonClickedEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
+            var cut = Render<ContentHeader>(parameters => parameters.Add(p => p.BackButtonClickedEvent, EventCallback.Factory.Create(this, () => eventTriggered = true)));
 
             // Act
             cut.Instance.BackButtonClickedEvent.InvokeAsync(true);

--- a/SiemensIXBlazor.Tests/ContentTests.cs
+++ b/SiemensIXBlazor.Tests/ContentTests.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
             var expectedContent = "Expected content";
 
             // Act
-            var cut = RenderComponent<Content>(parameters => parameters
+            var cut = Render<Content>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, expectedContent);

--- a/SiemensIXBlazor.Tests/DateDropdownTest.cs
+++ b/SiemensIXBlazor.Tests/DateDropdownTest.cs
@@ -21,7 +21,7 @@ public class DateDropdownTest : TestContextBase
     [Fact]
     public void OfficialPropertiesRender()
     {
-        var cut = RenderComponent<DateDropdown>(parameters => parameters
+        var cut = Render<DateDropdown>(parameters => parameters
             .Add(p => p.Id, "date-dropdown")
             .Add(p => p.DateRangeId, "last-week")
             .Add(p => p.Format, "yyyy/LL/dd")
@@ -47,7 +47,7 @@ public class DateDropdownTest : TestContextBase
     public async Task DateRangeChangeEventDeserializesOfficialPayload()
     {
         DateDropdownResponse? received = null;
-        var cut = RenderComponent<DateDropdown>(parameters => parameters
+        var cut = Render<DateDropdown>(parameters => parameters
             .Add(p => p.Id, "date-dropdown")
             .Add(p => p.DateRangeChangeEvent,
                 EventCallback.Factory.Create<DateDropdownResponse>(this, value => received = value)));

--- a/SiemensIXBlazor.Tests/DateInputTest.cs
+++ b/SiemensIXBlazor.Tests/DateInputTest.cs
@@ -20,7 +20,7 @@ public class DateInputTest : TestContextBase
     public void EnableTopLayerDefaultsToFalse()
     {
         // Arrange
-        var cut = RenderComponent<DateInput>(parameters => parameters
+        var cut = Render<DateInput>(parameters => parameters
             .Add(p => p.Id, "test-id"));
 
         // Assert
@@ -32,7 +32,7 @@ public class DateInputTest : TestContextBase
     public void EnableTopLayerTrueRendersAttribute()
     {
         // Arrange
-        var cut = RenderComponent<DateInput>(parameters => parameters
+        var cut = Render<DateInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.EnableTopLayer, true));
 
@@ -46,7 +46,7 @@ public class DateInputTest : TestContextBase
     {
         // Arrange
         var received = string.Empty;
-        var cut = RenderComponent<DateInput>(parameters => parameters
+        var cut = Render<DateInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string?>(this, (string? val) => received = val)));
 
@@ -62,7 +62,7 @@ public class DateInputTest : TestContextBase
     {
         // Arrange
         string? received = "initial";
-        var cut = RenderComponent<DateInput>(parameters => parameters
+        var cut = Render<DateInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string?>(this, (string? val) => received = val)));
 

--- a/SiemensIXBlazor.Tests/DatePickerTest.cs
+++ b/SiemensIXBlazor.Tests/DatePickerTest.cs
@@ -20,7 +20,7 @@ public class DatePickerTest : TestContextBase
     [Fact]
     public void OfficialPropertiesRender()
     {
-        var cut = RenderComponent<DatePicker>(parameters => parameters
+        var cut = Render<DatePicker>(parameters => parameters
             .Add(p => p.Id, "date-picker")
             .Add(p => p.Format, "dd/LL/yyyy")
             .Add(p => p.SingleSelection, true)
@@ -42,7 +42,7 @@ public class DatePickerTest : TestContextBase
     public async Task EventsDeserializeDateRangePayload()
     {
         DatePickerResponse? received = null;
-        var cut = RenderComponent<DatePicker>(parameters => parameters
+        var cut = Render<DatePicker>(parameters => parameters
             .Add(p => p.Id, "date-picker")
             .Add(p => p.DateSelectEvent,
                 EventCallback.Factory.Create<DatePickerResponse>(this, value => received = value)));

--- a/SiemensIXBlazor.Tests/DateTimeInputTest.cs
+++ b/SiemensIXBlazor.Tests/DateTimeInputTest.cs
@@ -21,7 +21,7 @@ public class DateTimeInputTest : TestContextBase
     [Fact]
     public void OfficialPropertiesAndSlotsRender()
     {
-        var cut = RenderComponent<DateTimeInput>(parameters => parameters
+        var cut = Render<DateTimeInput>(parameters => parameters
             .Add(p => p.Id, "datetime-input")
             .Add(p => p.Format, "yyyy/LL/dd HH:mm")
             .Add(p => p.TextAlignment, InputTextAlignment.End)
@@ -39,7 +39,7 @@ public class DateTimeInputTest : TestContextBase
     {
         string? value = null;
         DateTimeInputValidityState? validity = null;
-        var cut = RenderComponent<DateTimeInput>(parameters => parameters
+        var cut = Render<DateTimeInput>(parameters => parameters
             .Add(p => p.Id, "datetime-input")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<string?>(this, item => value = item))
             .Add(p => p.ValidityStateChangeEvent, EventCallback.Factory.Create<DateTimeInputValidityState>(this, item => validity = item)));

--- a/SiemensIXBlazor.Tests/DateTimePickerTest.cs
+++ b/SiemensIXBlazor.Tests/DateTimePickerTest.cs
@@ -21,7 +21,7 @@ public class DateTimePickerTest : TestContextBase
     [Fact]
     public void OfficialPropertiesRender()
     {
-        var cut = RenderComponent<DateTimePicker>(parameters => parameters
+        var cut = Render<DateTimePicker>(parameters => parameters
             .Add(p => p.Id, "datetime-picker")
             .Add(p => p.MinTime, "08:00")
             .Add(p => p.MaxTime, "18:00")
@@ -40,7 +40,7 @@ public class DateTimePickerTest : TestContextBase
     public async Task DateChangePreservesOfficialStringAndRangeForms()
     {
         var received = new List<DateTimeDateChangeEvent>();
-        var cut = RenderComponent<DateTimePicker>(parameters => parameters
+        var cut = Render<DateTimePicker>(parameters => parameters
             .Add(p => p.Id, "datetime-picker")
             .Add(p => p.DateChangeEvent,
                 EventCallback.Factory.Create<DateTimeDateChangeEvent>(this, value => received.Add(value))));

--- a/SiemensIXBlazor.Tests/DividerTest.cs
+++ b/SiemensIXBlazor.Tests/DividerTest.cs
@@ -18,7 +18,7 @@ public class DividerTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<Divider>(parameters => parameters
+        var cut = Render<Divider>(parameters => parameters
             .Add(p => p.Class, "testClass")
             .Add(p => p.Style, "testStyle"));
 

--- a/SiemensIXBlazor.Tests/DrawerTest.cs
+++ b/SiemensIXBlazor.Tests/DrawerTest.cs
@@ -19,18 +19,18 @@ namespace SiemensIXBlazor.Tests
         public void DrawerRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Drawer>(
-                ("Id", "testId"),
-                ("CloseOnClickOutside", true),
-                ("FullHeight", false),
-                ("MaxWidth", 28),
-                ("MinWidth", 16),
-                ("Show", true),
-                ("Width", 16)
+            var cut = Render<Drawer>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.CloseOnClickOutside, true)
+                .Add(p => p.FullHeight, false)
+                .Add(p => p.MaxWidth, 28)
+                .Add(p => p.MinWidth, 16)
+                .Add(p => p.Show, true)
+                .Add(p => p.Width, 16)
             );
 
             // Assert
-            cut.MarkupMatches("<ix-drawer minwidth=\"16\" id=\"testId\" show=\"\" close-on-click-outside=\"\" max-width=\"28\" min-width=\"16\" width=\"16\"></ix-drawer>");
+            cut.MarkupMatches("<ix-drawer id=\"testId\" show=\"\" close-on-click-outside=\"\" max-width=\"28\" min-width=\"16\" width=\"16\"></ix-drawer>");
         }
 
         [Fact]
@@ -38,9 +38,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var closed = false;
-            var cut = RenderComponent<Drawer>(
-                ("Id", "drawer"),
-                ("ClosedEvent", EventCallback.Factory.Create(this, () => closed = true))
+            var cut = Render<Drawer>(parameters => parameters
+                .Add(p => p.Id, "drawer")
+                .Add(p => p.ClosedEvent, EventCallback.Factory.Create(this, () => closed = true))
             );
 
             // Act
@@ -55,9 +55,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var opened = false;
-            var cut = RenderComponent<Drawer>(
-                ("Id", "drawer"),
-                ("OpenedEvent", EventCallback.Factory.Create(this, () => opened = true))
+            var cut = Render<Drawer>(parameters => parameters
+                .Add(p => p.Id, "drawer")
+                .Add(p => p.OpenedEvent, EventCallback.Factory.Create(this, () => opened = true))
             );
 
             // Act

--- a/SiemensIXBlazor.Tests/Dropdown/DropdownHeaderTests.cs
+++ b/SiemensIXBlazor.Tests/Dropdown/DropdownHeaderTests.cs
@@ -18,7 +18,7 @@ namespace SiemensIXBlazor.Tests.Dropdown
         public void DropdownHeaderRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<DropdownHeader>(parameters => {
+            var cut = Render<DropdownHeader>(parameters => {
                 parameters.Add(p => p.Label, "testLabel");
             });
 
@@ -29,7 +29,7 @@ namespace SiemensIXBlazor.Tests.Dropdown
         [Fact]
         public void DropdownHeaderDoesNotExposeChildContent()
         {
-            var cut = RenderComponent<DropdownHeader>();
+            var cut = Render<DropdownHeader>((Action<Bunit.ComponentParameterCollectionBuilder<DropdownHeader>>)(_ => { }));
 
             Assert.DoesNotContain("ChildContent", cut.Markup);
         }

--- a/SiemensIXBlazor.Tests/Dropdown/DropdownItemTest.cs
+++ b/SiemensIXBlazor.Tests/Dropdown/DropdownItemTest.cs
@@ -20,7 +20,7 @@ public class DropdownItemTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<DropdownItem>(parameters => parameters
+        var cut = Render<DropdownItem>(parameters => parameters
             .Add(p => p.Label, "testLabel")
             .Add(p => p.Icon, "testIcon")
             .Add(p => p.AriaLabelIcon, "icon label")
@@ -39,7 +39,7 @@ public class DropdownItemTest : TestContextBase
     [Fact]
     public void RendersEndContentSlot()
     {
-        var cut = RenderComponent<DropdownItem>(parameters => parameters
+        var cut = Render<DropdownItem>(parameters => parameters
             .Add(p => p.EndContent, (RenderFragment)(builder => builder.AddContent(0, "End content"))));
 
         cut.MarkupMatches("<ix-dropdown-item item-role=\"menuitem\"><div slot=\"end\">End content</div></ix-dropdown-item>");

--- a/SiemensIXBlazor.Tests/Dropdown/DropdownQuickActionsTest.cs
+++ b/SiemensIXBlazor.Tests/Dropdown/DropdownQuickActionsTest.cs
@@ -18,7 +18,7 @@ public class DropdownQuickActionsTest : TestContextBase
     [Fact]
     public void RendersChildContent()
     {
-        var cut = RenderComponent<DropdownQuickActions>(parameters => parameters
+        var cut = Render<DropdownQuickActions>(parameters => parameters
             .Add(p => p.ChildContent,
                 (RenderFragment)(builder => builder.AddContent(0, "Quick action"))));
 

--- a/SiemensIXBlazor.Tests/Dropdown/DropdownTest.cs
+++ b/SiemensIXBlazor.Tests/Dropdown/DropdownTest.cs
@@ -19,7 +19,7 @@ public class DropdownTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<Components.Dropdown>(parameters => parameters
+        var cut = Render<Components.Dropdown>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.Anchor, "testAnchor")
             .Add(p => p.CloseBehavior, DropdownButtonCloseBehavior.both)
@@ -48,7 +48,7 @@ public class DropdownTest : TestContextBase
         var showChange = false;
         var showChanged = false;
 
-        var cut = RenderComponent<Components.Dropdown>(parameters => parameters
+        var cut = Render<Components.Dropdown>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.ShowChangeEvent,
                 EventCallback.Factory.Create<bool>(this, value => showChange = value))
@@ -67,7 +67,7 @@ public class DropdownTest : TestContextBase
     [Fact]
     public void SupportsBooleanCloseBehavior()
     {
-        var cut = RenderComponent<Components.Dropdown>(parameters => parameters
+        var cut = Render<Components.Dropdown>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.CloseBehavior, false));
 

--- a/SiemensIXBlazor.Tests/DropdownButtonTest.cs
+++ b/SiemensIXBlazor.Tests/DropdownButtonTest.cs
@@ -21,7 +21,7 @@ public class DropdownButtonTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<DropdownButton>(parameters => parameters
+        var cut = Render<DropdownButton>(parameters => parameters
             .Add(p => p.Disabled, true)
             .Add(p => p.Icon, "testIcon")
             .Add(p => p.CloseBehavior, DropdownButtonCloseBehavior.both)
@@ -45,7 +45,7 @@ public class DropdownButtonTest : TestContextBase
     public void EnableTopLayerDefaultsToFalse()
     {
         // Arrange
-        var cut = RenderComponent<DropdownButton>(parameters => parameters
+        var cut = Render<DropdownButton>(parameters => parameters
             .Add(p => p.Label, "test"));
 
         // Assert
@@ -57,7 +57,7 @@ public class DropdownButtonTest : TestContextBase
     public void EnableTopLayerTrueRendersAttribute()
     {
         // Arrange
-        var cut = RenderComponent<DropdownButton>(parameters => parameters
+        var cut = Render<DropdownButton>(parameters => parameters
             .Add(p => p.Label, "test")
             .Add(p => p.EnableTopLayer, true));
 
@@ -71,7 +71,7 @@ public class DropdownButtonTest : TestContextBase
     {
         var showChange = false;
         var showChanged = false;
-        var cut = RenderComponent<DropdownButton>(parameters => parameters
+        var cut = Render<DropdownButton>(parameters => parameters
             .Add(p => p.ShowChangeEvent,
                 EventCallback.Factory.Create<bool>(this, value => showChange = value))
             .Add(p => p.ShowChangedEvent,
@@ -87,7 +87,7 @@ public class DropdownButtonTest : TestContextBase
     [Fact]
     public void RendersButtonLabelSlot()
     {
-        var cut = RenderComponent<DropdownButton>(parameters => parameters
+        var cut = Render<DropdownButton>(parameters => parameters
             .Add(p => p.ButtonLabelContent,
                 (RenderFragment)(builder => builder.AddContent(0, "Additional label"))));
 

--- a/SiemensIXBlazor.Tests/EChartsTest.cs
+++ b/SiemensIXBlazor.Tests/EChartsTest.cs
@@ -18,7 +18,7 @@ public class EChartsTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<ECharts>(parameters => parameters
+        var cut = Render<ECharts>(parameters => parameters
             .Add(p => p.Id, "testId"));
 
         // Assert

--- a/SiemensIXBlazor.Tests/EmptyStateTest.cs
+++ b/SiemensIXBlazor.Tests/EmptyStateTest.cs
@@ -19,7 +19,7 @@ public class EmptyStateTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<EmptyState>(parameters => parameters
+        var cut = Render<EmptyState>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.Action, "testAction")
             .Add(p => p.Header, "testHeader")
@@ -37,7 +37,7 @@ public class EmptyStateTest : TestContextBase
     {
         // Arrange
         var eventCalled = false;
-        var cut = RenderComponent<EmptyState>(parameters => parameters
+        var cut = Render<EmptyState>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.ActionClickedEvent, EventCallback.Factory.Create(this, () => eventCalled = true)));
 

--- a/SiemensIXBlazor.Tests/EventList/EventListItemTest.cs
+++ b/SiemensIXBlazor.Tests/EventList/EventListItemTest.cs
@@ -19,7 +19,7 @@ public class EventListItemTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<EventListItem>(parameters => parameters
+        var cut = Render<EventListItem>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Chevron, true)
@@ -38,7 +38,7 @@ public class EventListItemTest : TestContextBase
     [Fact]
     public void DefaultBooleanPropertiesMatchOfficialDefaults()
     {
-        var cut = RenderComponent<EventListItem>(parameters => parameters.Add(p => p.Id, "testId"));
+        var cut = Render<EventListItem>(parameters => parameters.Add(p => p.Id, "testId"));
 
         Assert.False(cut.Instance.Chevron);
         Assert.False(cut.Instance.Disabled);
@@ -51,7 +51,7 @@ public class EventListItemTest : TestContextBase
     {
         // Arrange
         var wasClicked = false;
-        var cut = RenderComponent<EventListItem>(parameters => parameters
+        var cut = Render<EventListItem>(parameters => parameters
             .Add(p => p.ItemClickEvent, EventCallback.Factory.Create(this, () => wasClicked = true)));
 
         // Act

--- a/SiemensIXBlazor.Tests/EventList/EventListTest.cs
+++ b/SiemensIXBlazor.Tests/EventList/EventListTest.cs
@@ -18,7 +18,7 @@ public class EventListTest : TestContextBase
     public void EventListPropertiesAreSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.EventList>(parameters => parameters
+        var cut = Render<Components.EventList>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Animated, true)
             .Add(p => p.Chevron, true)
@@ -33,7 +33,7 @@ public class EventListTest : TestContextBase
     [Fact]
     public void NumericItemHeightRendersCorrectly()
     {
-        var cut = RenderComponent<Components.EventList>(parameters => parameters
+        var cut = Render<Components.EventList>(parameters => parameters
             .Add(p => p.ItemHeight, 48));
 
         Assert.Equal("48", cut.Find("ix-event-list").GetAttribute("item-height"));
@@ -42,7 +42,7 @@ public class EventListTest : TestContextBase
     [Fact]
     public void DefaultPropertiesMatchOfficialDefaults()
     {
-        var cut = RenderComponent<Components.EventList>();
+        var cut = Render<Components.EventList>((Action<Bunit.ComponentParameterCollectionBuilder<Components.EventList>>)(_ => { }));
 
         Assert.Equal("S", cut.Instance.ItemHeight);
         Assert.False(cut.Instance.Animated);

--- a/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
+++ b/SiemensIXBlazor.Tests/ExpandingSearchTest.cs
@@ -20,7 +20,7 @@ public class ExpandingSearchTest : TestContextBase
     public void ComponentRendersWithCorrectProperties()
     {
         // Arrange
-        var cut = RenderComponent<ExpandingSearch>(parameters => parameters
+        var cut = Render<ExpandingSearch>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.Icon, "testIcon")
             .Add(p => p.Placeholder, "testPlaceholder")
@@ -42,7 +42,7 @@ public class ExpandingSearchTest : TestContextBase
     {
         // Arrange
         var valueChangedEventInvoked = false;
-        var cut = RenderComponent<ExpandingSearch>(parameters => parameters
+        var cut = Render<ExpandingSearch>(parameters => parameters
             .Add(p => p.ValueChangedEvent,
                 EventCallback.Factory.Create<string>(this, _ => valueChangedEventInvoked = true)));
 

--- a/SiemensIXBlazor.Tests/Flip/FlipTileContentTest.cs
+++ b/SiemensIXBlazor.Tests/Flip/FlipTileContentTest.cs
@@ -19,7 +19,7 @@ public class FlipTileContentTest : TestContextBase
     public void ComponentRendersAndPropertiesSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<FlipTileContent>(parameters => parameters.Add(p => p.ChildContent,
+        var cut = Render<FlipTileContent>(parameters => parameters.Add(p => p.ChildContent,
             (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
 
         // Assert

--- a/SiemensIXBlazor.Tests/Flip/FlipTileTest.cs
+++ b/SiemensIXBlazor.Tests/Flip/FlipTileTest.cs
@@ -20,7 +20,7 @@ public class FlipTileTest : TestContextBase
     public void ComponentRendersAndSetsPropertiesCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Variant, FlipTileVariant.primary)
@@ -36,7 +36,7 @@ public class FlipTileTest : TestContextBase
     public void ComponentRendersWithAllPropertiesSet()
     {
         // Arrange
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip-complete")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Full test")))
             .Add(p => p.Variant, FlipTileVariant.warning)
@@ -54,7 +54,7 @@ public class FlipTileTest : TestContextBase
     {
         var isToggleEventOccured = false;
 
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Variant, FlipTileVariant.alarm)
@@ -76,7 +76,7 @@ public class FlipTileTest : TestContextBase
     public void DefaultVariantIsFilled()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
 
@@ -89,7 +89,7 @@ public class FlipTileTest : TestContextBase
     public void DefaultHeightAndWidthAreSet()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip"));
 
         // Assert
@@ -101,7 +101,7 @@ public class FlipTileTest : TestContextBase
     public void DefaultIndexIsZero()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip"));
 
         // Assert
@@ -112,7 +112,7 @@ public class FlipTileTest : TestContextBase
     public void AriaLabelEyeIconButtonRendersWhenSet()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.AriaLabelEyeIconButton, "Show details"));
 
@@ -125,7 +125,7 @@ public class FlipTileTest : TestContextBase
     public void AriaLabelEyeIconButtonIsOptional()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip"));
 
         // Assert
@@ -136,7 +136,7 @@ public class FlipTileTest : TestContextBase
     public void CustomHeightAndWidthRenderCorrectly()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.Height, 50)
             .Add(p => p.Width, 60));
@@ -150,7 +150,7 @@ public class FlipTileTest : TestContextBase
     [Fact]
     public void AutoHeightAndWidthRenderCorrectly()
     {
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip-auto")
             .Add(p => p.Height, "auto")
             .Add(p => p.Width, "auto"));
@@ -164,7 +164,7 @@ public class FlipTileTest : TestContextBase
     [Fact]
     public void NumberAndAutoDimensionsAreAccepted()
     {
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip-values")
             .Add(p => p.Height, 20.5)
             .Add(p => p.Width, "auto"));
@@ -179,7 +179,7 @@ public class FlipTileTest : TestContextBase
     public void IndexPropertyRenders()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.Index, 7));
 
@@ -199,7 +199,7 @@ public class FlipTileTest : TestContextBase
     public void AllVariantsRenderCorrectly(FlipTileVariant variant, string expectedVariant)
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.Variant, variant)
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
@@ -216,7 +216,7 @@ public class FlipTileTest : TestContextBase
         var complexContent = "<div class=\"test\"><span>Complex</span> content</div>";
 
         // Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, complexContent))));
 
@@ -232,7 +232,7 @@ public class FlipTileTest : TestContextBase
         // Arrange
         int receivedIndex = -1;
 
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .Add(p => p.Index, 42)
             .Add(p => p.ToggleEvent, EventCallback.Factory.Create<int>(this, (index) => receivedIndex = index)));
@@ -248,7 +248,7 @@ public class FlipTileTest : TestContextBase
     public void IdIsRequiredAndRendersCorrectly()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "custom-flip-id"));
 
         // Assert
@@ -260,7 +260,7 @@ public class FlipTileTest : TestContextBase
     public void ComponentSupportsUserAttributes()
     {
         // Arrange & Act
-        var cut = RenderComponent<FlipTile>(parameters => parameters
+        var cut = Render<FlipTile>(parameters => parameters
             .Add(p => p.Id, "ix-flip")
             .AddUnmatched("data-testid", "flip-test")
             .AddUnmatched("custom-attr", "custom-value"));

--- a/SiemensIXBlazor.Tests/FormFieldTests.cs
+++ b/SiemensIXBlazor.Tests/FormFieldTests.cs
@@ -27,7 +27,7 @@ public class FormFieldTests : TestContextBase
     [Fact]
     public void InputRendersOfficialDefaultsAndProperties()
     {
-        var cut = RenderComponent<Input>(parameters => parameters
+        var cut = Render<Input>(parameters => parameters
             .Add(p => p.Id, "input")
             .Add(p => p.Type, InputType.Email)
             .Add(p => p.SuppressSubmitOnEnter, true)
@@ -42,7 +42,7 @@ public class FormFieldTests : TestContextBase
     [Fact]
     public void NumberInputSupportsNullableValueAndOfficialProperties()
     {
-        var cut = RenderComponent<NumberInput>(parameters => parameters
+        var cut = Render<NumberInput>(parameters => parameters
             .Add(p => p.Id, "number")
             .Add(p => p.AllowEmptyValueChange, true)
             .Add(p => p.Value, null)
@@ -58,7 +58,7 @@ public class FormFieldTests : TestContextBase
     public async Task NumberInputEmitsNullableValue()
     {
         double? received = 1;
-        var cut = RenderComponent<NumberInput>(parameters => parameters
+        var cut = Render<NumberInput>(parameters => parameters
             .Add(p => p.Id, "number")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<double?>(this, value => received = value)));
 
@@ -71,7 +71,7 @@ public class FormFieldTests : TestContextBase
     [Fact]
     public void TextAreaUsesTypedResizeBehavior()
     {
-        var cut = RenderComponent<TextArea>(parameters => parameters
+        var cut = Render<TextArea>(parameters => parameters
             .Add(p => p.Id, "textarea")
             .Add(p => p.ResizeBehavior, TextAreaResizeBehavior.Vertical));
 
@@ -82,7 +82,7 @@ public class FormFieldTests : TestContextBase
     public async Task InputValidityStateUsesTypedCallback()
     {
         ValidityState? received = null;
-        var cut = RenderComponent<Input>(parameters => parameters
+        var cut = Render<Input>(parameters => parameters
             .Add(p => p.Id, "input")
             .Add(p => p.ValidityStateChangeEvent,
                 EventCallback.Factory.Create<ValidityState>(this, value => received = value)));
@@ -96,7 +96,7 @@ public class FormFieldTests : TestContextBase
     [Fact]
     public void CustomFieldOnlyRendersItsDefaultSlot()
     {
-        var cut = RenderComponent<CustomField>(parameters => parameters
+        var cut = Render<CustomField>(parameters => parameters
             .Add(p => p.Id, "custom")
             .AddChildContent("control"));
 
@@ -107,11 +107,11 @@ public class FormFieldTests : TestContextBase
     [Fact]
     public void FieldLabelAndHelperTextMapTheirPublicAttributes()
     {
-        var label = RenderComponent<FieldLabel>(parameters => parameters
+        var label = Render<FieldLabel>(parameters => parameters
             .Add(p => p.HtmlFor, "input")
             .Add(p => p.Required, true)
             .AddChildContent("Label"));
-        var helper = RenderComponent<HelperText>(parameters => parameters
+        var helper = Render<HelperText>(parameters => parameters
             .Add(p => p.HtmlFor, "input")
             .Add(p => p.HelperText, "Help")
             .Add(p => p.InvalidText, "Error"));

--- a/SiemensIXBlazor.Tests/Group/GroupItemTest.cs
+++ b/SiemensIXBlazor.Tests/Group/GroupItemTest.cs
@@ -19,7 +19,7 @@ public class GroupItemTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<GroupItem>(parameters => parameters
+        var cut = Render<GroupItem>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.Disabled, true)
             .Add(p => p.Icon, "testIcon")
@@ -39,7 +39,7 @@ public class GroupItemTest : TestContextBase
     {
         // Arrange
         var wasCalled = false;
-        var cut = RenderComponent<GroupItem>(parameters => parameters
+        var cut = Render<GroupItem>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.SelectedChangeEvent, EventCallback.Factory.Create<string>(this, id => { wasCalled = true; })));
 
@@ -54,7 +54,7 @@ public class GroupItemTest : TestContextBase
     public void ComponentRendersWithChildContent()
     {
         // Arrange
-        var cut = RenderComponent<GroupItem>(parameters => parameters
+        var cut = Render<GroupItem>(parameters => parameters
             .Add(p => p.Id, "testId")
             .AddChildContent("<button>Custom Entry</button>"));
 

--- a/SiemensIXBlazor.Tests/Group/GroupTest.cs
+++ b/SiemensIXBlazor.Tests/Group/GroupTest.cs
@@ -18,7 +18,7 @@ public class GroupTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Group>(parameters => parameters
+        var cut = Render<Components.Group>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.Expanded, true)
             .Add(p => p.ExpandOnHeaderClick, false)
@@ -44,7 +44,7 @@ public class GroupTest : TestContextBase
         var selectGroupEventWasCalled = false;
         var selectItemEventValue = 0;
 
-        var cut = RenderComponent<Components.Group>(parameters => parameters
+        var cut = Render<Components.Group>(parameters => parameters
             .Add(p => p.Id, "testId")
             .Add(p => p.ExpandedChangedEvent,
                 EventCallback.Factory.Create(this, (bool value) => { expandedChangedEventWasCalled = true; }))

--- a/SiemensIXBlazor.Tests/InputTest.cs
+++ b/SiemensIXBlazor.Tests/InputTest.cs
@@ -21,7 +21,7 @@ public class InputTest : TestContextBase
     public void InputRendersWithId()
     {
         // Arrange & Act
-        var cut = RenderComponent<Input>(parameters => parameters
+        var cut = Render<Input>(parameters => parameters
             .Add(p => p.Id, "test-input"));
 
         // Assert
@@ -34,7 +34,7 @@ public class InputTest : TestContextBase
     {
         // Arrange
         var received = string.Empty;
-        var cut = RenderComponent<Input>(parameters => parameters
+        var cut = Render<Input>(parameters => parameters
             .Add(p => p.Id, "test-input")
             .Add(p => p.IxChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 
@@ -50,7 +50,7 @@ public class InputTest : TestContextBase
     {
         // Arrange
         var received = "initial";
-        var cut = RenderComponent<Input>(parameters => parameters
+        var cut = Render<Input>(parameters => parameters
             .Add(p => p.Id, "test-input")
             .Add(p => p.IxChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 

--- a/SiemensIXBlazor.Tests/KPITest.cs
+++ b/SiemensIXBlazor.Tests/KPITest.cs
@@ -19,7 +19,7 @@ public class KPITest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<KPI>(parameters => parameters
+        var cut = Render<KPI>(parameters => parameters
             .Add(p => p.Label, "testLabel")
             .Add(p => p.Orientation, KpiOrientation.Horizontal)
             .Add(p => p.State, KpiState.Neutral)
@@ -35,7 +35,7 @@ public class KPITest : TestContextBase
     [Fact]
     public void ComponentRendersNumericValueWithoutUnsupportedAttributes()
     {
-        var cut = RenderComponent<KPI>(parameters => parameters
+        var cut = Render<KPI>(parameters => parameters
             .Add(p => p.Label, "Temperature")
             .Add(p => p.Value, 42)
             .Add(p => p.State, KpiState.Warning)

--- a/SiemensIXBlazor.Tests/KeyValueListTest.cs
+++ b/SiemensIXBlazor.Tests/KeyValueListTest.cs
@@ -19,7 +19,7 @@ public class KeyValueListTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<KeyValueList>(parameters => parameters
+        var cut = Render<KeyValueList>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Striped, true));
 

--- a/SiemensIXBlazor.Tests/KeyValueTest.cs
+++ b/SiemensIXBlazor.Tests/KeyValueTest.cs
@@ -20,7 +20,7 @@ public class KeyValueTest : TestContextBase
     public void ComponentRendersCustomValueThroughNamedSlot()
     {
         // Arrange
-        var cut = RenderComponent<KeyValue>(parameters => parameters
+        var cut = Render<KeyValue>(parameters => parameters
             .Add(p => p.CustomValue, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Icon, "testIcon")
             .Add(p => p.AriaLabelIcon, "Test icon")
@@ -42,7 +42,7 @@ public class KeyValueTest : TestContextBase
     public void ComponentUsesTextValueInsteadOfCustomValueSlotWhenValueIsSet()
     {
         // Arrange
-        var cut = RenderComponent<KeyValue>(parameters => parameters
+        var cut = Render<KeyValue>(parameters => parameters
             .Add(p => p.CustomValue, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Label, "testLabel")
             .Add(p => p.Value, "testValue"));
@@ -57,7 +57,7 @@ public class KeyValueTest : TestContextBase
     public void ComponentUsesOfficialDefaultLabelPosition()
     {
         // Arrange
-        var cut = RenderComponent<KeyValue>(parameters => parameters
+        var cut = Render<KeyValue>(parameters => parameters
             .Add(p => p.Label, "testLabel"));
 
         // Assert

--- a/SiemensIXBlazor.Tests/LayoutAuto/LayoutAutoTests.cs
+++ b/SiemensIXBlazor.Tests/LayoutAuto/LayoutAutoTests.cs
@@ -20,7 +20,7 @@ public class LayoutAutoTests : TestContextBase
     [Fact]
     public void ComponentRendersChildContentAndId()
     {
-        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+        var cut = Render<LayoutAuto>(parameters => parameters
             .Add(p => p.Id, "layout-auto")
             .Add(p => p.ChildContent, (RenderFragment)(builder =>
                 builder.AddMarkupContent(0, "Test content"))));
@@ -31,7 +31,7 @@ public class LayoutAutoTests : TestContextBase
     [Fact]
     public void LayoutDefaultsMatchOfficialValues()
     {
-        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+        var cut = Render<LayoutAuto>(parameters => parameters
             .Add(p => p.Id, "layout-auto"));
 
         Assert.Equal(
@@ -52,7 +52,7 @@ public class LayoutAutoTests : TestContextBase
             new LayoutAutoItem { MinWidth = "64em", Columns = 3 }
         };
 
-        var cut = RenderComponent<LayoutAuto>(parameters => parameters
+        var cut = Render<LayoutAuto>(parameters => parameters
             .Add(p => p.Id, "layout-auto")
             .Add(p => p.Layout, layout));
 

--- a/SiemensIXBlazor.Tests/LayoutGrid/ColTest.cs
+++ b/SiemensIXBlazor.Tests/LayoutGrid/ColTest.cs
@@ -20,7 +20,7 @@ public class ColTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Col>(parameters => parameters
+        var cut = Render<Col>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Size, ColumnSize._12)
             .Add(p => p.SizeLg, ColumnSize._10)
@@ -34,7 +34,7 @@ public class ColTest : TestContextBase
     [Fact]
     public void ComponentRendersWithoutSizeAttributesByDefault()
     {
-        var cut = RenderComponent<Col>();
+        var cut = Render<Col>((Action<Bunit.ComponentParameterCollectionBuilder<Col>>)(_ => { }));
 
         cut.MarkupMatches("<ix-col></ix-col>");
     }
@@ -42,7 +42,7 @@ public class ColTest : TestContextBase
     [Fact]
     public void ComponentRendersAutoColumnSize()
     {
-        var cut = RenderComponent<Col>(parameters => parameters
+        var cut = Render<Col>(parameters => parameters
             .Add(p => p.Size, ColumnSize.auto));
 
         cut.MarkupMatches("<ix-col size=\"auto\"></ix-col>");

--- a/SiemensIXBlazor.Tests/LayoutGrid/LayoutGridTest.cs
+++ b/SiemensIXBlazor.Tests/LayoutGrid/LayoutGridTest.cs
@@ -19,7 +19,7 @@ public class LayoutGridTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.LayoutGrid.LayoutGrid>(parameters => parameters
+        var cut = Render<Components.LayoutGrid.LayoutGrid>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Columns, 12)
             .Add(p => p.Gap, LayoutGridGap._24)

--- a/SiemensIXBlazor.Tests/LayoutGrid/RowTest.cs
+++ b/SiemensIXBlazor.Tests/LayoutGrid/RowTest.cs
@@ -19,7 +19,7 @@ public class RowTest : TestContextBase
     public void ComponentRendersWithChildContent()
     {
         // Arrange
-        var cut = RenderComponent<Row>(parameters => parameters
+        var cut = Render<Row>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
 
         // Assert

--- a/SiemensIXBlazor.Tests/LinkButtonTest.cs
+++ b/SiemensIXBlazor.Tests/LinkButtonTest.cs
@@ -20,7 +20,7 @@ public class LinkButtonTest : TestContextBase
     public void ComponentRendersWithParametersSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<LinkButton>(parameters => parameters
+        var cut = Render<LinkButton>(parameters => parameters
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
             .Add(p => p.Disabled, true)
             .Add(p => p.Target, LinkButtonTarget._blank)

--- a/SiemensIXBlazor.Tests/Menu/MenuAvatarItemTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuAvatarItemTest.cs
@@ -20,12 +20,12 @@ namespace SiemensIXBlazor.Tests.Menu
         public void MenuAvatarItemRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatarItem>(
-                ("Id", "testId"),
-                ("Icon", "testIcon"),
-                ("Label", "Test Label"),
-                ("Class", "test-class"),
-                ("Style", "width: 100%")
+            var cut = Render<MenuAvatarItem>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Icon, "testIcon")
+                .Add(p => p.Label, "Test Label")
+                .Add(p => p.Class, "test-class")
+                .Add(p => p.Style, "width: 100%")
             );
 
             // Assert
@@ -38,9 +38,9 @@ namespace SiemensIXBlazor.Tests.Menu
         {
             // Arrange
             var clicked = false;
-            var cut = RenderComponent<MenuAvatarItem>(
-                ("Id", "navigationMenuAvatarItem"),
-                ("ItemClickedEvent", EventCallback.Factory.Create(this, (MouseEventArgs args) => clicked = true))
+            var cut = Render<MenuAvatarItem>(parameters => parameters
+                .Add(p => p.Id, "navigationMenuAvatarItem")
+                .Add(p => p.ItemClickedEvent, EventCallback.Factory.Create(this, (MouseEventArgs args) => clicked = true))
             );
 
             // Act

--- a/SiemensIXBlazor.Tests/Menu/MenuAvatarTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuAvatarTest.cs
@@ -19,17 +19,17 @@ namespace SiemensIXBlazor.Tests.Menu
         public void MenuAvatarRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(
-                ("Id", "testId"),
-                ("Class", "test-class"),
-                ("Style", "width: 100%"),
-                ("Bottom", "Bottom Text"),
-                ("I18nLogout", "Logout"),
-                ("Image", "testImage"),
-                ("Initials", "TI"),
-                ("Top", "Top Text"),
-                ("HideLogoutButton", true),
-                ("ChildContent", (RenderFragment)(builder =>
+            var cut = Render<MenuAvatar>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Class, "test-class")
+                .Add(p => p.Style, "width: 100%")
+                .Add(p => p.Bottom, "Bottom Text")
+                .Add(p => p.I18nLogout, "Logout")
+                .Add(p => p.Image, "testImage")
+                .Add(p => p.Initials, "TI")
+                .Add(p => p.Top, "Top Text")
+                .Add(p => p.HideLogoutButton, true)
+                .Add(p => p.ChildContent, (RenderFragment)(builder =>
                 {
                     builder.OpenElement(0, "div");
                     builder.AddContent(1, "Test child content");
@@ -46,9 +46,9 @@ namespace SiemensIXBlazor.Tests.Menu
         {
             // Arrange
             var clicked = false;
-            var cut = RenderComponent<MenuAvatar>(
-                ("Id", "navigationMenuAvatar"),
-                ("LogoutClickedEvent", EventCallback.Factory.Create(this, () => clicked = true))
+            var cut = Render<MenuAvatar>(parameters => parameters
+                .Add(p => p.Id, "navigationMenuAvatar")
+                .Add(p => p.LogoutClickedEvent, EventCallback.Factory.Create(this, () => clicked = true))
             );
 
             // Act
@@ -62,7 +62,7 @@ namespace SiemensIXBlazor.Tests.Menu
         public void EnableTopLayerDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(parameters => parameters
+            var cut = Render<MenuAvatar>(parameters => parameters
                 .Add(p => p.Id, "test-id"));
 
             // Assert
@@ -74,7 +74,7 @@ namespace SiemensIXBlazor.Tests.Menu
         public void EnableTopLayerTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(parameters => parameters
+            var cut = Render<MenuAvatar>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.EnableTopLayer, true));
 
@@ -87,7 +87,7 @@ namespace SiemensIXBlazor.Tests.Menu
         public void TooltipTextPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(parameters => parameters
+            var cut = Render<MenuAvatar>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.TooltipText, "Test tooltip"));
 
@@ -100,7 +100,7 @@ namespace SiemensIXBlazor.Tests.Menu
         public void AriaLabelTooltipPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(parameters => parameters
+            var cut = Render<MenuAvatar>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.AriaLabelTooltip, "Tooltip label"));
 
@@ -113,7 +113,7 @@ namespace SiemensIXBlazor.Tests.Menu
         public void TooltipTextAndAriaLabelTooltipCanBeCombined()
         {
             // Arrange
-            var cut = RenderComponent<MenuAvatar>(parameters => parameters
+            var cut = Render<MenuAvatar>(parameters => parameters
                 .Add(p => p.Id, "test-id")
                 .Add(p => p.TooltipText, "Hover text")
                 .Add(p => p.AriaLabelTooltip, "Screen reader text"));

--- a/SiemensIXBlazor.Tests/Menu/MenuCategoryTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuCategoryTest.cs
@@ -19,17 +19,17 @@ namespace SiemensIXBlazor.Tests.Menu
         public void MenuCategoryRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuCategory>(
-                ("Icon", "testIcon"),
-                ("Label", "Test Label"),
-                ("Notifications", 5),
-                ("ChildContent", (RenderFragment)(builder =>
+            var cut = Render<MenuCategory>(parameters => parameters
+                .Add(p => p.Icon, "testIcon")
+                .Add(p => p.Label, "Test Label")
+                .Add(p => p.Notifications, 5)
+                .Add(p => p.ChildContent, (RenderFragment)(builder =>
                 {
                     builder.OpenElement(0, "div");
                     builder.AddContent(1, "Test child content");
                     builder.CloseElement();
-                })),
-                ("TooltipText", "Test tooltip")
+                }))
+                .Add(p => p.TooltipText, "Test tooltip")
             );
 
             // Assert

--- a/SiemensIXBlazor.Tests/Menu/MenuItemTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuItemTest.cs
@@ -20,21 +20,21 @@ namespace SiemensIXBlazor.Tests.Menu
 		public void MenuItemRendersCorrectly()
 		{
 			// Arrange
-			var cut = RenderComponent<MenuItem>(
-				("Active", true),
-				("Disabled", false),
-				("Home", true),
-				("Bottom", true),
-				("Icon", "testIcon"),
-				("Notifications", 5),
-				("Label", "label"),
-				("ChildContent", (RenderFragment)(builder =>
+			var cut = Render<MenuItem>(parameters => parameters
+			    .Add(p => p.Active, true)
+			    .Add(p => p.Disabled, false)
+			    .Add(p => p.Home, true)
+			    .Add(p => p.Bottom, true)
+			    .Add(p => p.Icon, "testIcon")
+			    .Add(p => p.Notifications, 5)
+			    .Add(p => p.Label, "label")
+			    .Add(p => p.ChildContent, (RenderFragment)(builder =>
 				{
 					builder.OpenElement(0, "div");
 					builder.AddContent(1, "Test child content");
 					builder.CloseElement();
-				})),
-				("TooltipText", "Test tooltip")
+				}))
+			    .Add(p => p.TooltipText, "Test tooltip")
 			);
 
 			// Assert
@@ -45,7 +45,7 @@ namespace SiemensIXBlazor.Tests.Menu
 		[Fact]
 		public void RendersLinkAttributes()
 		{
-			var cut = RenderComponent<MenuItem>(parameters => parameters
+			var cut = Render<MenuItem>(parameters => parameters
 				.Add(p => p.Label, "Documentation")
 				.Add(p => p.Href, "/docs")
 				.Add(p => p.Target, MenuItemTarget._blank)

--- a/SiemensIXBlazor.Tests/Menu/MenuTest.cs
+++ b/SiemensIXBlazor.Tests/Menu/MenuTest.cs
@@ -17,7 +17,7 @@ public class MenuTest : TestContextBase
     [Fact]
     public void RendersCurrentPublicProperties()
     {
-        var cut = RenderComponent<Components.Menu.Menu>(parameters => parameters
+        var cut = Render<Components.Menu.Menu>(parameters => parameters
             .Add(p => p.Id, "menu")
             .Add(p => p.ApplicationName, "Application")
             .Add(p => p.ApplicationDescription, "Description")
@@ -52,7 +52,7 @@ public class MenuTest : TestContextBase
         var appSwitch = false;
         var settings = false;
         var about = false;
-        var cut = RenderComponent<Components.Menu.Menu>(parameters => parameters
+        var cut = Render<Components.Menu.Menu>(parameters => parameters
             .Add(p => p.Id, "menu")
             .Add(p => p.ExpandChangedEvent, EventCallback.Factory.Create<bool>(this, value => expand = value))
             .Add(p => p.MapExpandChangedEvent, EventCallback.Factory.Create<bool>(this, value => mapExpand = value))

--- a/SiemensIXBlazor.Tests/MenuAbout/MenuAboutItemTest.cs
+++ b/SiemensIXBlazor.Tests/MenuAbout/MenuAboutItemTest.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests.MenuAbout
         public void ComponentRendersWithoutCrashing()
         {
             // Arrange
-            var cut = RenderComponent<MenuAboutItem>();
+            var cut = Render<MenuAboutItem>((Action<Bunit.ComponentParameterCollectionBuilder<MenuAboutItem>>)(_ => { }));
 
             // Assert
             cut.MarkupMatches("<ix-menu-about-item></ix-menu-about-item>");
@@ -30,7 +30,7 @@ namespace SiemensIXBlazor.Tests.MenuAbout
         public void ChildContentPropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAboutItem>(parameters => parameters.Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
+            var cut = Render<MenuAboutItem>(parameters => parameters.Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content"))));
 
             // Assert
             Assert.NotNull(cut.Instance.ChildContent);
@@ -40,7 +40,7 @@ namespace SiemensIXBlazor.Tests.MenuAbout
         public void LablePropertyIsSetCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<MenuAboutItem>(parameters => parameters.Add(p => p.Label, "testLabel"));
+            var cut = Render<MenuAboutItem>(parameters => parameters.Add(p => p.Label, "testLabel"));
 
             // Assert
             Assert.Equal("testLabel", cut.Instance.Label);
@@ -50,7 +50,7 @@ namespace SiemensIXBlazor.Tests.MenuAbout
         public async Task RendersTabKeyAndForwardsLabelChange()
         {
             MenuLabelChangeEvent? changed = null;
-            var cut = RenderComponent<MenuAboutItem>(parameters => parameters
+            var cut = Render<MenuAboutItem>(parameters => parameters
                 .Add(p => p.Id, "about-legal")
                 .Add(p => p.TabKey, "legal")
                 .Add(p => p.Label, "Legal")

--- a/SiemensIXBlazor.Tests/MenuAbout/MenuAboutNewsTest.cs
+++ b/SiemensIXBlazor.Tests/MenuAbout/MenuAboutNewsTest.cs
@@ -18,7 +18,7 @@ public class MenuAboutNewsTest : TestContextBase
     [Fact]
     public void RendersCurrentPublicProperties()
     {
-        var cut = RenderComponent<Components.MenuAbout.MenuAboutNews>(parameters => parameters
+        var cut = Render<Components.MenuAbout.MenuAboutNews>(parameters => parameters
             .Add(p => p.Id, "news")
             .Add(p => p.Label, "Release notes")
             .Add(p => p.AboutItemLabel, "News")
@@ -36,7 +36,7 @@ public class MenuAboutNewsTest : TestContextBase
     {
         var closed = false;
         MouseEventArgs? mouseEvent = null;
-        var cut = RenderComponent<Components.MenuAbout.MenuAboutNews>(parameters => parameters
+        var cut = Render<Components.MenuAbout.MenuAboutNews>(parameters => parameters
             .Add(p => p.ClosePopoverEvent, EventCallback.Factory.Create(this, () => closed = true))
             .Add(p => p.ShowMoreEvent, EventCallback.Factory.Create<MouseEventArgs>(this, value => mouseEvent = value)));
         var expected = new MouseEventArgs();

--- a/SiemensIXBlazor.Tests/MenuAbout/MenuAboutTest.cs
+++ b/SiemensIXBlazor.Tests/MenuAbout/MenuAboutTest.cs
@@ -18,7 +18,7 @@ public class MenuAboutTest : TestContextBase
     [Fact]
     public void RendersCurrentPublicProperties()
     {
-        var cut = RenderComponent<Components.MenuAbout.MenuAbout>(parameters => parameters
+        var cut = Render<Components.MenuAbout.MenuAbout>(parameters => parameters
             .Add(p => p.Id, "about")
             .Add(p => p.ActiveTabKey, "legal")
             .Add(p => p.SuppressLegacyTabs, true)
@@ -37,7 +37,7 @@ public class MenuAboutTest : TestContextBase
     {
         MenuCloseEvent? close = null;
         var tabKey = string.Empty;
-        var cut = RenderComponent<Components.MenuAbout.MenuAbout>(parameters => parameters
+        var cut = Render<Components.MenuAbout.MenuAbout>(parameters => parameters
             .Add(p => p.ClosedEvent, EventCallback.Factory.Create<MenuCloseEvent>(this, value => close = value))
             .Add(p => p.TabChangedEvent, EventCallback.Factory.Create<string>(this, value => tabKey = value)));
         var expected = new MenuCloseEvent { Name = "ix-menu-about" };

--- a/SiemensIXBlazor.Tests/MenuSettings/MenuSettingsItemTest.cs
+++ b/SiemensIXBlazor.Tests/MenuSettings/MenuSettingsItemTest.cs
@@ -26,9 +26,10 @@ namespace SiemensIXBlazor.Tests.MenuSettings
             };
 
             // Act
-            var cut = RenderComponent<MenuSettingsItem>(
-                ("Label", "Test Label"),
-                ("ChildContent", childContent));
+            var cut = Render<MenuSettingsItem>(parameters => parameters
+                .Add(p => p.Label, "Test Label")
+                .Add(p => p.ChildContent, childContent)
+            );
 
             // Assert
 			cut.MarkupMatches("<ix-menu-settings-item label=\"Test Label\">Simple Text</ix-menu-settings-item>");
@@ -38,7 +39,7 @@ namespace SiemensIXBlazor.Tests.MenuSettings
 		public async Task RendersTabKeyAndForwardsLabelChange()
 		{
 			MenuLabelChangeEvent? changed = null;
-			var cut = RenderComponent<MenuSettingsItem>(parameters => parameters
+			var cut = Render<MenuSettingsItem>(parameters => parameters
 				.Add(p => p.Id, "settings-general")
 				.Add(p => p.TabKey, "general")
 				.Add(p => p.Label, "General")

--- a/SiemensIXBlazor.Tests/MenuSettings/MenuSettingsTest.cs
+++ b/SiemensIXBlazor.Tests/MenuSettings/MenuSettingsTest.cs
@@ -18,7 +18,7 @@ public class MenuSettingsTest : TestContextBase
     [Fact]
     public void RendersCurrentPublicProperties()
     {
-        var cut = RenderComponent<Components.MenuSettings.MenuSettings>(parameters => parameters
+        var cut = Render<Components.MenuSettings.MenuSettings>(parameters => parameters
             .Add(p => p.Id, "settings")
             .Add(p => p.ActiveTabKey, "general")
             .Add(p => p.SuppressLegacyTabs, true)
@@ -37,7 +37,7 @@ public class MenuSettingsTest : TestContextBase
     {
         MenuCloseEvent? close = null;
         var tabKey = string.Empty;
-        var cut = RenderComponent<Components.MenuSettings.MenuSettings>(parameters => parameters
+        var cut = Render<Components.MenuSettings.MenuSettings>(parameters => parameters
             .Add(p => p.ClosedEvent, EventCallback.Factory.Create<MenuCloseEvent>(this, value => close = value))
             .Add(p => p.TabChangedEvent, EventCallback.Factory.Create<string>(this, value => tabKey = value)));
         var expected = new MenuCloseEvent { Name = "ix-menu-settings" };

--- a/SiemensIXBlazor.Tests/MessageBarTest.cs
+++ b/SiemensIXBlazor.Tests/MessageBarTest.cs
@@ -28,13 +28,14 @@ public class MessageBarTests : TestContextBase
         };
 
         // Act
-        var cut = RenderComponent<MessageBar>(
-            ("Id", "testId"),
-            ("Class", "test-class"),
-            ("Style", "width: 100%"),
-            ("Persistent", true),
-            ("Type", MessageBarType.Info),
-            ("ChildContent", childContent));
+        var cut = Render<MessageBar>(parameters => parameters
+            .Add(p => p.Id, "testId")
+            .Add(p => p.Class, "test-class")
+            .Add(p => p.Style, "width: 100%")
+            .Add(p => p.Persistent, true)
+            .Add(p => p.Type, MessageBarType.Info)
+            .Add(p => p.ChildContent, childContent)
+        );
 
         // Assert
         cut.MarkupMatches("<ix-message-bar id=\"testId\" class=\"test-class\" style=\"width: 100%\" persistent=\"\" type=\"info\">Simple Text</ix-message-bar>");
@@ -45,9 +46,9 @@ public class MessageBarTests : TestContextBase
     {
         // Arrange
         var closed = false;
-        var cut = RenderComponent<MessageBar>(
-            ("Id", "messageBar"),
-            ("ClosedChangeEvent", EventCallback.Factory.Create(this, () => closed = true))
+        var cut = Render<MessageBar>(parameters => parameters
+            .Add(p => p.Id, "messageBar")
+            .Add(p => p.ClosedChangeEvent, EventCallback.Factory.Create(this, () => closed = true))
         );
 
         // Act
@@ -62,9 +63,9 @@ public class MessageBarTests : TestContextBase
     {
         // Arrange
         var animationCompleted = false;
-        var cut = RenderComponent<MessageBar>(
-            ("Id", "messageBar"),
-            ("CloseAnimationCompletedEvent", EventCallback.Factory.Create(this, () => animationCompleted = true))
+        var cut = Render<MessageBar>(parameters => parameters
+            .Add(p => p.Id, "messageBar")
+            .Add(p => p.CloseAnimationCompletedEvent, EventCallback.Factory.Create(this, () => animationCompleted = true))
         );
 
         // Act

--- a/SiemensIXBlazor.Tests/Modal/ModalContentTest.cs
+++ b/SiemensIXBlazor.Tests/Modal/ModalContentTest.cs
@@ -21,7 +21,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalContent_ShouldRenderBasicProperties()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalContent>(parameters => parameters
+            var component = Render<ModalContent>(parameters => parameters
                 .Add(p => p.Class, "custom-class")
                 .Add(p => p.Style, "color: red;")
             );
@@ -37,7 +37,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalContent_ShouldRenderChildContent()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalContent>(parameters => parameters
+            var component = Render<ModalContent>(parameters => parameters
                 .AddChildContent("<p>Modal content text</p>")
             );
 
@@ -50,7 +50,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalContent_ShouldRenderWithoutProperties()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalContent>();
+            var component = Render<ModalContent>((Action<Bunit.ComponentParameterCollectionBuilder<ModalContent>>)(_ => { }));
 
             // Assert
             var element = component.Find("ix-modal-content");
@@ -61,7 +61,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalContent_ShouldApplyCssClass()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalContent>(parameters => parameters
+            var component = Render<ModalContent>(parameters => parameters
                 .Add(p => p.Class, "test-class another-class")
             );
 
@@ -75,7 +75,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalContent_ShouldApplyStyleAttribute()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalContent>(parameters => parameters
+            var component = Render<ModalContent>(parameters => parameters
                 .Add(p => p.Style, "background-color: blue; margin: 10px;")
             );
 

--- a/SiemensIXBlazor.Tests/Modal/ModalFooterTest.cs
+++ b/SiemensIXBlazor.Tests/Modal/ModalFooterTest.cs
@@ -21,7 +21,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldRenderBasicProperties()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>(parameters => parameters
+            var component = Render<ModalFooter>(parameters => parameters
                 .Add(p => p.Class, "custom-class")
                 .Add(p => p.Style, "color: red;")
             );
@@ -37,7 +37,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldRenderChildContent()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>(parameters => parameters
+            var component = Render<ModalFooter>(parameters => parameters
                 .AddChildContent("<button>Close</button><button>Save</button>")
             );
 
@@ -51,7 +51,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldRenderActionButtons()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>(parameters => parameters
+            var component = Render<ModalFooter>(parameters => parameters
                 .AddChildContent(
                     @"<ix-button>Cancel</ix-button>
                       <ix-button variant=""primary"">Confirm</ix-button>"
@@ -69,7 +69,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldRenderWithoutProperties()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>();
+            var component = Render<ModalFooter>((Action<Bunit.ComponentParameterCollectionBuilder<ModalFooter>>)(_ => { }));
 
             // Assert
             var element = component.Find("ix-modal-footer");
@@ -80,7 +80,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldApplyCssClass()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>(parameters => parameters
+            var component = Render<ModalFooter>(parameters => parameters
                 .Add(p => p.Class, "test-class footer-class")
             );
 
@@ -94,7 +94,7 @@ namespace SiemensIXBlazor.Tests.Modal
         public void ModalFooter_ShouldApplyStyleAttribute()
         {
             // Arrange & Act
-            var component = RenderComponent<ModalFooter>(parameters => parameters
+            var component = Render<ModalFooter>(parameters => parameters
                 .Add(p => p.Style, "text-align: right; padding: 20px;")
             );
 

--- a/SiemensIXBlazor.Tests/Modal/ModalHeaderTest.cs
+++ b/SiemensIXBlazor.Tests/Modal/ModalHeaderTest.cs
@@ -19,7 +19,7 @@ public class ModalHeaderTest : TestContextBase
     [Fact]
     public void ModalHeader_ShouldRenderOfficialProperties()
     {
-        var component = RenderComponent<ModalHeader>(parameters => parameters
+        var component = Render<ModalHeader>(parameters => parameters
             .Add(p => p.HideClose, true)
             .Add(p => p.Icon, "info")
             .Add(p => p.AriaLabelIcon, "Information")
@@ -39,7 +39,7 @@ public class ModalHeaderTest : TestContextBase
     [Fact]
     public void ModalHeader_ShouldUseOfficialCloseLabelByDefault()
     {
-        var component = RenderComponent<ModalHeader>();
+        var component = Render<ModalHeader>((Action<Bunit.ComponentParameterCollectionBuilder<ModalHeader>>)(_ => { }));
 
         Assert.Equal("Close modal", component.Instance.AriaLabelCloseIconButton);
     }

--- a/SiemensIXBlazor.Tests/Modal/ModalServiceTest.cs
+++ b/SiemensIXBlazor.Tests/Modal/ModalServiceTest.cs
@@ -28,7 +28,7 @@ public class ModalServiceTest : TestContextBase
         Services.AddSingleton<ModalService>(services =>
             new ModalService(services.GetRequiredService<IJSRuntime>()));
         var service = Services.GetRequiredService<ModalService>();
-        var host = RenderComponent<ModalHost>();
+        var host = Render<ModalHost>((Action<Bunit.ComponentParameterCollectionBuilder<ModalHost>>)(_ => { }));
 
         var config = new ModalConfig
         {
@@ -60,7 +60,7 @@ public class ModalServiceTest : TestContextBase
         Services.AddSingleton<ModalService>(services =>
             new ModalService(services.GetRequiredService<IJSRuntime>()));
         var service = Services.GetRequiredService<ModalService>();
-        var host = RenderComponent<ModalHost>();
+        var host = Render<ModalHost>((Action<Bunit.ComponentParameterCollectionBuilder<ModalHost>>)(_ => { }));
         var wasCalled = false;
         var config = new ModalConfig
         {

--- a/SiemensIXBlazor.Tests/PaginationTest.cs
+++ b/SiemensIXBlazor.Tests/PaginationTest.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void PaginationRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Pagination>(parameters =>
+            var cut = Render<Pagination>(parameters =>
                 {
                     parameters.Add(p => p.Id, "testId");
                     parameters.Add(p => p.ItemCount, 15);
@@ -38,9 +38,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var itemCount = 0;
-            var cut = RenderComponent<Components.Pagination.Pagination>(
-                ("Id", "pagination"),
-                ("ItemCountChangedEvent", EventCallback.Factory.Create(this, (int count) => itemCount = count))
+            var cut = Render<Components.Pagination.Pagination>(parameters => parameters
+                .Add(p => p.Id, "pagination")
+                .Add(p => p.ItemCountChangedEvent, EventCallback.Factory.Create(this, (int count) => itemCount = count))
             );
 
             // Act
@@ -55,9 +55,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var selectedPage = 0;
-            var cut = RenderComponent<Components.Pagination.Pagination>(
-                ("Id", "pagination"),
-                ("PageSelectedEvent", EventCallback.Factory.Create(this, (int page) => selectedPage = page))
+            var cut = Render<Components.Pagination.Pagination>(parameters => parameters
+                .Add(p => p.Id, "pagination")
+                .Add(p => p.PageSelectedEvent, EventCallback.Factory.Create(this, (int page) => selectedPage = page))
             );
 
             // Act
@@ -71,7 +71,7 @@ namespace SiemensIXBlazor.Tests
         public void ItemCountOptionsIsNullByDefault()
         {
             // Arrange & Act
-            var cut = RenderComponent<Components.Pagination.Pagination>(parameters =>
+            var cut = Render<Components.Pagination.Pagination>(parameters =>
                 parameters.Add(p => p.Id, "testId")
             );
 
@@ -84,7 +84,7 @@ namespace SiemensIXBlazor.Tests
         public void ItemCountOptionsRendersAsCommaSeparatedString()
         {
             // Arrange & Act
-            var cut = RenderComponent<Components.Pagination.Pagination>(parameters =>
+            var cut = Render<Components.Pagination.Pagination>(parameters =>
             {
                 parameters.Add(p => p.Id, "testId");
                 parameters.Add(p => p.ItemCountOptions, new[] { 15, 25, 50 });

--- a/SiemensIXBlazor.Tests/PaneLayoutTest.cs
+++ b/SiemensIXBlazor.Tests/PaneLayoutTest.cs
@@ -15,17 +15,17 @@ using Xunit;
 
 namespace SiemensIXBlazor.Tests
 {
-    public class PaneLayoutTests : TestContext
+    public class PaneLayoutTests : TestContextBase
     {
         [Fact]
         public void PaneLayoutRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<PaneLayout>(
-                ("Borderless", true),
-                ("Layout", "full-vertical"),
-                ("Variant", PaneVariant.inline),
-                ("ChildContent", (RenderFragment)(builder => builder.AddMarkupContent(0, "<div>Test content</div>")))
+            var cut = Render<PaneLayout>(parameters => parameters
+                .Add(p => p.Borderless, true)
+                .Add(p => p.Layout, "full-vertical")
+                .Add(p => p.Variant, PaneVariant.inline)
+                .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "<div>Test content</div>")))
             );
 
             // Assert
@@ -35,7 +35,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void PaneLayoutRendersNamedSlots()
         {
-            var cut = RenderComponent<PaneLayout>(parameters => parameters
+            var cut = Render<PaneLayout>(parameters => parameters
                 .Add(p => p.Left, builder => builder.AddContent(0, "Left content"))
                 .Add(p => p.Top, builder => builder.AddContent(0, "Top content"))
                 .Add(p => p.Content, builder => builder.AddContent(0, "Content area"))

--- a/SiemensIXBlazor.Tests/PaneTest.cs
+++ b/SiemensIXBlazor.Tests/PaneTest.cs
@@ -22,19 +22,19 @@ namespace SiemensIXBlazor.Tests
         public void PaneRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Pane>(
-                ("Id", "testId"),
-                ("Borderless", true),
-                ("NoPadding", true),
-                ("Composition", PaneComposition.top),
-                ("Expanded", true),
-                ("CloseOnClickOutside", true),
-                ("Heading", "Test Heading"),
-                ("HideOnCollapse", true),
-                ("Icon", "Test Icon"),
-                ("Size", "240px"),
-                ("Variant", PaneVariant.inline),
-                ("AriaLabelCollapseCloseButton", "testAriaLabelCollapseCloseButton")
+            var cut = Render<Pane>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Borderless, true)
+                .Add(p => p.NoPadding, true)
+                .Add(p => p.Composition, PaneComposition.top)
+                .Add(p => p.Expanded, true)
+                .Add(p => p.CloseOnClickOutside, true)
+                .Add(p => p.Heading, "Test Heading")
+                .Add(p => p.HideOnCollapse, true)
+                .Add(p => p.Icon, "Test Icon")
+                .Add(p => p.Size, "240px")
+                .Add(p => p.Variant, PaneVariant.inline)
+                .Add(p => p.AriaLabelCollapseCloseButton, "testAriaLabelCollapseCloseButton")
             );
 
             // Assert
@@ -44,7 +44,9 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void PaneUsesOfficialDefaultValues()
         {
-            var cut = RenderComponent<Pane>(("Id", "default-pane"));
+            var cut = Render<Pane>(parameters => parameters
+                .Add(p => p.Id, "default-pane")
+            );
 
             Assert.DoesNotContain("close-on-click-outside", cut.Markup);
             Assert.DoesNotContain("no-padding", cut.Markup);
@@ -57,9 +59,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var expandedChanged = false;
-            var cut = RenderComponent<Pane>(
-                ("Id", "pane"),
-                ("ExpandedChangedEvent", EventCallback.Factory.Create<PaneExpandedChangedEventResponse>(this, newValue => { expandedChanged = true; }))
+            var cut = Render<Pane>(parameters => parameters
+                .Add(p => p.Id, "pane")
+                .Add(p => p.ExpandedChangedEvent, EventCallback.Factory.Create<PaneExpandedChangedEventResponse>(this, newValue => { expandedChanged = true; }))
             );
 
             // Act
@@ -74,9 +76,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var borderlessChanged = false;
-            var cut = RenderComponent<Pane>(
-                ("Id", "pane"),
-                ("BorderlessChangedEvent", EventCallback.Factory.Create<PaneBorderlessChangedEventResponse>(this, newValue => { borderlessChanged = true; }))
+            var cut = Render<Pane>(parameters => parameters
+                .Add(p => p.Id, "pane")
+                .Add(p => p.BorderlessChangedEvent, EventCallback.Factory.Create<PaneBorderlessChangedEventResponse>(this, newValue => { borderlessChanged = true; }))
             );
 
             // Act
@@ -91,9 +93,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var variantChanged = false;
-            var cut = RenderComponent<Pane>(
-                ("Id", "pane"),
-                ("VariantChangedEvent", EventCallback.Factory.Create<PaneVariantChangedEventResponse>(this, newValue => { variantChanged = true; }))
+            var cut = Render<Pane>(parameters => parameters
+                .Add(p => p.Id, "pane")
+                .Add(p => p.VariantChangedEvent, EventCallback.Factory.Create<PaneVariantChangedEventResponse>(this, newValue => { variantChanged = true; }))
             );
 
             // Act
@@ -110,7 +112,7 @@ namespace SiemensIXBlazor.Tests
             var expectedHeaderContent = "Header content";
 
             // Act
-            var cut = RenderComponent<Pane>(parameters => parameters
+            var cut = Render<Pane>(parameters => parameters
                 .Add(p => p.Id, "testPane")
                 .Add(p => p.HeaderContent, builder => 
                 {
@@ -127,7 +129,7 @@ namespace SiemensIXBlazor.Tests
         public void PaneDoesNotRenderHeaderSlotWhenNull()
         {
             // Arrange & Act
-            var cut = RenderComponent<Pane>(parameters => {
+            var cut = Render<Pane>(parameters => {
                 parameters.Add(p => p.Id, "testPane");
                 parameters.Add(p => p.Heading, "Test Heading");
             });
@@ -140,7 +142,7 @@ namespace SiemensIXBlazor.Tests
         public async Task ExpandedChangedDeserializesOfficialBooleanPayload()
         {
             PaneExpandedChangedEventResponse? response = null;
-            var cut = RenderComponent<Pane>(parameters => parameters
+            var cut = Render<Pane>(parameters => parameters
                 .Add(p => p.Id, "pane-event")
                 .Add(p => p.ExpandedChangedEvent, EventCallback.Factory.Create<PaneExpandedChangedEventResponse>(this, value => response = value)));
 

--- a/SiemensIXBlazor.Tests/PillTest.cs
+++ b/SiemensIXBlazor.Tests/PillTest.cs
@@ -20,7 +20,7 @@ namespace SiemensIXBlazor.Tests
         public void PillRendersWithAllParameters()
         {
             // Arrange & Act
-            var cut = RenderComponent<Pill>(parameters =>
+            var cut = Render<Pill>(parameters =>
             {
                 parameters.Add(p => p.AlignLeft, true);
                 parameters.Add(p => p.Background, "red");
@@ -45,7 +45,7 @@ namespace SiemensIXBlazor.Tests
         public void PillRendersWithDefaultParameters()
         {
             // Act
-            var cut = RenderComponent<Pill>();
+            var cut = Render<Pill>((Action<Bunit.ComponentParameterCollectionBuilder<Pill>>)(_ => { }));
 
             // Assert
             cut.MarkupMatches("<ix-pill variant=\"primary\"></ix-pill>");
@@ -58,7 +58,7 @@ namespace SiemensIXBlazor.Tests
             var content = "Simple Text";
 
             // Act
-            var cut = RenderComponent<Pill>(parameters =>
+            var cut = Render<Pill>(parameters =>
             {
                 parameters.Add(p => p.ChildContent, (RenderFragment)(builder =>
                 {
@@ -74,7 +74,7 @@ namespace SiemensIXBlazor.Tests
         public void PillHasBooleanAttributes()
         {
             // Act
-            var cut = RenderComponent<Pill>(parameters =>
+            var cut = Render<Pill>(parameters =>
             {
                 parameters.Add(p => p.AlignLeft, true);
                 parameters.Add(p => p.Outline, true);

--- a/SiemensIXBlazor.Tests/Popover/PopoverTests.cs
+++ b/SiemensIXBlazor.Tests/Popover/PopoverTests.cs
@@ -19,7 +19,7 @@ public class PopoverTests : TestContextBase
     [Fact]
     public void Popover_RendersOfficialPropertiesAndChildContent()
     {
-        var cut = RenderComponent<Components.Popover>(parameters => parameters
+        var cut = Render<Components.Popover>(parameters => parameters
             .Add(p => p.Id, "popover")
             .Add(p => p.Trigger, "popover-trigger")
             .Add(p => p.Show, true)
@@ -47,7 +47,7 @@ public class PopoverTests : TestContextBase
         var showChange = false;
         var showChanged = false;
 
-        var cut = RenderComponent<Components.Popover>(parameters => parameters
+        var cut = Render<Components.Popover>(parameters => parameters
             .Add(p => p.Id, "popover")
             .Add(p => p.ShowChangeEvent, EventCallback.Factory.Create<bool>(this, value => showChange = value))
             .Add(p => p.ShowChangedEvent, EventCallback.Factory.Create<bool>(this, value => showChanged = value)));
@@ -62,7 +62,7 @@ public class PopoverTests : TestContextBase
     [Fact]
     public void PopoverHeader_RendersPropertiesAndNamedSlot()
     {
-        var cut = RenderComponent<Components.PopoverHeader>(parameters => parameters
+        var cut = Render<Components.PopoverHeader>(parameters => parameters
             .Add(p => p.Id, "popover-header")
             .Add(p => p.Icon, "info")
             .Add(p => p.IconColor, "#007993")
@@ -87,7 +87,7 @@ public class PopoverTests : TestContextBase
     public async Task PopoverHeader_RaisesCloseClickEvent()
     {
         MouseEventArgs? received = null;
-        var cut = RenderComponent<Components.PopoverHeader>(parameters => parameters
+        var cut = Render<Components.PopoverHeader>(parameters => parameters
             .Add(p => p.Id, "popover-header")
             .Add(p => p.CloseClickEvent, EventCallback.Factory.Create<MouseEventArgs>(this, value => received = value)));
 
@@ -100,7 +100,7 @@ public class PopoverTests : TestContextBase
     [Fact]
     public void PopoverImage_RendersImageProperties()
     {
-        var cut = RenderComponent<Components.PopoverImage>(parameters => parameters
+        var cut = Render<Components.PopoverImage>(parameters => parameters
             .Add(p => p.Id, "popover-image")
             .Add(p => p.Image, "/images/example.png")
             .Add(p => p.ImageAlt, "Example image"));
@@ -115,7 +115,7 @@ public class PopoverTests : TestContextBase
     [Fact]
     public void PopoverContent_RendersNoPaddingAndChildContent()
     {
-        var cut = RenderComponent<Components.PopoverContent>(parameters => parameters
+        var cut = Render<Components.PopoverContent>(parameters => parameters
             .Add(p => p.Id, "popover-content")
             .Add(p => p.NoPadding, true)
             .AddChildContent("Popover content"));
@@ -130,7 +130,7 @@ public class PopoverTests : TestContextBase
     [Fact]
     public void PopoverFooter_RendersAlignmentAndStartSlot()
     {
-        var cut = RenderComponent<Components.PopoverFooter>(parameters => parameters
+        var cut = Render<Components.PopoverFooter>(parameters => parameters
             .Add(p => p.Id, "popover-footer")
             .Add(p => p.Alignment, PopoverFooterAlignment.Vertical)
             .Add(p => p.StartContent, (RenderFragment)(builder => builder.AddContent(0, "Metadata")))

--- a/SiemensIXBlazor.Tests/ProgressIndicatorTests.cs
+++ b/SiemensIXBlazor.Tests/ProgressIndicatorTests.cs
@@ -20,19 +20,19 @@ namespace SiemensIXBlazor.Tests
         public void ProgressIndicatorRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<ProgressIndicator>(
-                ("Value", 50.0),
-                ("Max", 100.0),
-                ("Min", 0.0),
-                ("Label", "Loading"),
-                ("HelperText", "Please wait"),
-                ("Size", ProgressIndicatorSize.md),
-                ("Status", ProgressIndicatorStatus.@default),
-                ("Type", ProgressIndicatorType.linear),
-                ("TextAlignment", ProgressIndicatorTextAlignment.left),
-                ("ShowTextAsTooltip", true),
-                ("Style", "margin: 10px;"),
-                ("Class", "test-class")
+            var cut = Render<ProgressIndicator>(parameters => parameters
+                .Add(p => p.Value, 50.0)
+                .Add(p => p.Max, 100.0)
+                .Add(p => p.Min, 0.0)
+                .Add(p => p.Label, "Loading")
+                .Add(p => p.HelperText, "Please wait")
+                .Add(p => p.Size, ProgressIndicatorSize.md)
+                .Add(p => p.Status, ProgressIndicatorStatus.@default)
+                .Add(p => p.Type, ProgressIndicatorType.linear)
+                .Add(p => p.TextAlignment, ProgressIndicatorTextAlignment.left)
+                .Add(p => p.ShowTextAsTooltip, true)
+                .Add(p => p.Style, "margin: 10px;")
+                .Add(p => p.Class, "test-class")
             );
 
             // Assert
@@ -43,10 +43,10 @@ namespace SiemensIXBlazor.Tests
         public void ProgressIndicatorWithCircularType()
         {
             // Arrange
-            var cut = RenderComponent<ProgressIndicator>(
-                ("Type", ProgressIndicatorType.circular),
-                ("Value", 75.0),
-                ("Status", ProgressIndicatorStatus.success)
+            var cut = Render<ProgressIndicator>(parameters => parameters
+                .Add(p => p.Type, ProgressIndicatorType.circular)
+                .Add(p => p.Value, 75.0)
+                .Add(p => p.Status, ProgressIndicatorStatus.success)
             );
 
             // Assert
@@ -57,10 +57,10 @@ namespace SiemensIXBlazor.Tests
         public void ProgressIndicatorWithTooltip()
         {
             // Arrange
-            var cut = RenderComponent<ProgressIndicator>(
-                ("ShowTextAsTooltip", true),
-                ("HelperText", "Tooltip text"),
-                ("Size", ProgressIndicatorSize.lg)
+            var cut = Render<ProgressIndicator>(parameters => parameters
+                .Add(p => p.ShowTextAsTooltip, true)
+                .Add(p => p.HelperText, "Tooltip text")
+                .Add(p => p.Size, ProgressIndicatorSize.lg)
             );
 
             // Assert
@@ -71,10 +71,10 @@ namespace SiemensIXBlazor.Tests
         public void ProgressIndicatorWithErrorStatus()
         {
             // Arrange
-            var cut = RenderComponent<ProgressIndicator>(
-                ("Status", ProgressIndicatorStatus.error),
-                ("Value", 25.0),
-                ("TextAlignment", ProgressIndicatorTextAlignment.center)
+            var cut = Render<ProgressIndicator>(parameters => parameters
+                .Add(p => p.Status, ProgressIndicatorStatus.error)
+                .Add(p => p.Value, 25.0)
+                .Add(p => p.TextAlignment, ProgressIndicatorTextAlignment.center)
             );
 
             // Assert
@@ -87,7 +87,7 @@ namespace SiemensIXBlazor.Tests
             var helperText = (RenderFragment)(builder => builder.AddContent(0, "Custom helper text"));
             var content = (RenderFragment)(builder => builder.AddContent(0, "50%"));
 
-            var cut = RenderComponent<ProgressIndicator>(parameters => parameters
+            var cut = Render<ProgressIndicator>(parameters => parameters
                 .Add(p => p.HelperTextContent, helperText)
                 .Add(p => p.ChildContent, content));
 

--- a/SiemensIXBlazor.Tests/PushCardTest.cs
+++ b/SiemensIXBlazor.Tests/PushCardTest.cs
@@ -19,14 +19,14 @@ namespace SiemensIXBlazor.Tests
         public void PushCardRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<PushCard>(
-                ("Heading", "Test Heading"),
-                ("Icon", "testIcon"),
-                ("AriaLabelIcon", "Test icon"),
-                ("Notification", "5"),
-                ("SubHeading", "Test SubHeading"),
-                ("Expanded", true),
-                ("Variant", PushCardVariant.outline)
+            var cut = Render<PushCard>(parameters => parameters
+                .Add(p => p.Heading, "Test Heading")
+                .Add(p => p.Icon, "testIcon")
+                .Add(p => p.AriaLabelIcon, "Test icon")
+                .Add(p => p.Notification, "5")
+                .Add(p => p.SubHeading, "Test SubHeading")
+                .Add(p => p.Expanded, true)
+                .Add(p => p.Variant, PushCardVariant.outline)
             );
 
             // Assert
@@ -38,7 +38,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveDefaultsToFalse()
         {
             // Arrange
-            var cut = RenderComponent<PushCard>();
+            var cut = Render<PushCard>((Action<Bunit.ComponentParameterCollectionBuilder<PushCard>>)(_ => { }));
 
             // Assert
             Assert.False(cut.Instance.Passive);
@@ -49,7 +49,7 @@ namespace SiemensIXBlazor.Tests
         public void PassiveTrueRendersAttribute()
         {
             // Arrange
-            var cut = RenderComponent<PushCard>(parameters => parameters
+            var cut = Render<PushCard>(parameters => parameters
                 .Add(p => p.Passive, true));
 
             // Assert
@@ -60,7 +60,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void ExpandedDefaultsToFalse()
         {
-            var cut = RenderComponent<PushCard>();
+            var cut = Render<PushCard>((Action<Bunit.ComponentParameterCollectionBuilder<PushCard>>)(_ => { }));
 
             Assert.False(cut.Instance.Expanded);
             Assert.DoesNotContain("expanded", cut.Markup);
@@ -69,7 +69,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void RendersDefaultAndTitleActionContent()
         {
-            var cut = RenderComponent<PushCard>(parameters => parameters
+            var cut = Render<PushCard>(parameters => parameters
                 .Add(p => p.ChildContent, builder => builder.AddContent(0, "Details"))
                 .Add(p => p.TitleAction, builder => builder.AddContent(0, "Action")));
 

--- a/SiemensIXBlazor.Tests/RadioGroupTest.cs
+++ b/SiemensIXBlazor.Tests/RadioGroupTest.cs
@@ -20,7 +20,7 @@ public class RadioGroupTests : TestContextBase
     [Fact]
     public void RendersPublicPropertiesAndChildContent()
     {
-        var cut = RenderComponent<RadioGroup>(parameters => parameters
+        var cut = Render<RadioGroup>(parameters => parameters
             .Add(p => p.Id, "radio-group")
             .Add(p => p.Label, "Storage options")
             .Add(p => p.HelperText, "Choose one")
@@ -39,7 +39,9 @@ public class RadioGroupTests : TestContextBase
     [Fact]
     public void DirectionDefaultsToColumn()
     {
-        var cut = RenderComponent<RadioGroup>(("Id", "radio-group"));
+        var cut = Render<RadioGroup>(parameters => parameters
+            .Add(p => p.Id, "radio-group")
+        );
 
         Assert.Equal(RadioGroupDirection.Column, cut.Instance.Direction);
         Assert.Equal("column", cut.Find("ix-radio-group").GetAttribute("direction"));
@@ -49,7 +51,7 @@ public class RadioGroupTests : TestContextBase
     public async Task ValueChangeEventUpdatesValueAndInvokesCallback()
     {
         string? received = null;
-        var cut = RenderComponent<RadioGroup>(parameters => parameters
+        var cut = Render<RadioGroup>(parameters => parameters
             .Add(p => p.Id, "radio-group")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<string>(this, value => received = value)));
 

--- a/SiemensIXBlazor.Tests/RangeFieldTest.cs
+++ b/SiemensIXBlazor.Tests/RangeFieldTest.cs
@@ -22,7 +22,7 @@ public class RangeFieldTest : TestContextBase
     [InlineData(RangeFieldType.DateTimeRange, "datetime-range")]
     public void TypeUsesOfficialAttributeValue(RangeFieldType type, string expected)
     {
-        var cut = RenderComponent<RangeField>(parameters => parameters
+        var cut = Render<RangeField>(parameters => parameters
             .Add(p => p.Type, type)
             .Add(p => p.HideArrow, true)
             .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddContent(0, "range inputs"))));

--- a/SiemensIXBlazor.Tests/Select/SelectItemTest.cs
+++ b/SiemensIXBlazor.Tests/Select/SelectItemTest.cs
@@ -20,7 +20,7 @@ public class SelectItemTests : TestContextBase
     public void ComponentRendersWithoutCrashing()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item"));
 
         // Assert
@@ -31,7 +31,7 @@ public class SelectItemTests : TestContextBase
     public void IdPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "custom-item-id"));
 
         // Assert
@@ -43,7 +43,7 @@ public class SelectItemTests : TestContextBase
     public void LabelPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Label, "Test Label"));
 
@@ -56,7 +56,7 @@ public class SelectItemTests : TestContextBase
     public void ValuePropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Value, "item-value"));
 
@@ -69,7 +69,7 @@ public class SelectItemTests : TestContextBase
     public void SelectedPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Selected, true));
 
@@ -81,7 +81,7 @@ public class SelectItemTests : TestContextBase
     [Fact]
     public void DisabledPropertyIsSetCorrectly()
     {
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Disabled, true));
 
@@ -93,7 +93,7 @@ public class SelectItemTests : TestContextBase
     public void ClassPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Class, "custom-class"));
 
@@ -106,7 +106,7 @@ public class SelectItemTests : TestContextBase
     public void StylePropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.Style, "color: red;"));
 
@@ -120,7 +120,7 @@ public class SelectItemTests : TestContextBase
     {
         // Arrange
         string? clickedItem = null;
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "test-select-item")
             .Add(p => p.ItemClickEvent, EventCallback.Factory.Create<string>(this, (item) => clickedItem = item)));
 
@@ -135,7 +135,7 @@ public class SelectItemTests : TestContextBase
     public void CompleteSelectItemRendersCorrectly()
     {
         // Arrange & Act
-        var cut = RenderComponent<SelectItem>(parameters => parameters
+        var cut = Render<SelectItem>(parameters => parameters
             .Add(p => p.Id, "selectItem1")
             .Add(p => p.Label, "Item 1")
             .Add(p => p.Value, "1")
@@ -152,7 +152,7 @@ public class SelectItemTests : TestContextBase
     public void SelectItemRendersWithinSelect()
     {
         // Arrange & Act
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "parent-select")
             .Add(p => p.Value, "1")
             .Add(p => p.ChildContent, builder =>

--- a/SiemensIXBlazor.Tests/Select/SelectTest.cs
+++ b/SiemensIXBlazor.Tests/Select/SelectTest.cs
@@ -21,7 +21,7 @@ public class SelectTests : TestContextBase
     public void ComponentRendersWithoutCrashing()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "1"));
 
@@ -36,7 +36,7 @@ public class SelectTests : TestContextBase
     public void IdPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "custom-id")
             .Add(p => p.Value, "1"));
 
@@ -52,7 +52,7 @@ public class SelectTests : TestContextBase
     public void AllowClearPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.AllowClear, true));
 
@@ -68,7 +68,7 @@ public class SelectTests : TestContextBase
     public void ModePropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "1")
             .Add(p => p.Mode, SelectMode.Multiple));
@@ -85,7 +85,7 @@ public class SelectTests : TestContextBase
     public void ValuePropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "testValue"));
 
@@ -101,7 +101,7 @@ public class SelectTests : TestContextBase
     public void MultipleValueSupportsStringArray()
     {
         var values = new[] { "1", "2" };
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Mode, SelectMode.Multiple)
             .Add(p => p.Value, values));
@@ -113,7 +113,7 @@ public class SelectTests : TestContextBase
     [Fact]
     public void OfficialLocalizationAndMultipleSelectionPropertiesRender()
     {
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.AriaLabelAddItem, "Add option")
             .Add(p => p.I18nMoreItems, "{count} additional")
@@ -132,7 +132,7 @@ public class SelectTests : TestContextBase
     public void ClassPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "1")
             .Add(p => p.Class, "ix-warning"));
@@ -149,7 +149,7 @@ public class SelectTests : TestContextBase
     public void WarningTextPropertyIsSetCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "1")
             .Add(p => p.WarningText, "This is a warning text"));
@@ -167,7 +167,7 @@ public class SelectTests : TestContextBase
     public void ChildContentIsRenderedCorrectly()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.Value, "1")
             .Add(p => p.ChildContent, builder =>
@@ -193,7 +193,7 @@ public class SelectTests : TestContextBase
     {
         // Arrange
         string? addedItem = null;
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.AddItemEvent, EventCallback.Factory.Create<string>(this, (item) => addedItem = item)));
 
@@ -209,7 +209,7 @@ public class SelectTests : TestContextBase
     {
         // Arrange
         string? changedValue = null;
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<object?>(this, value => changedValue = value?.ToString())));
 
@@ -226,7 +226,7 @@ public class SelectTests : TestContextBase
     {
         // Arrange
         string[]? changedValues = null;
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<object?>(this, value => changedValues = value as string[])));
 
@@ -246,7 +246,7 @@ public class SelectTests : TestContextBase
     {
         // Arrange
         string? changedInput = null;
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.InputChangeEvent, EventCallback.Factory.Create<string>(this, (input) => changedInput = input)));
 
@@ -262,7 +262,7 @@ public class SelectTests : TestContextBase
     {
         // Arrange
         bool blurTriggered = false;
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.BlurEvent, EventCallback.Factory.Create<object>(this, (_) => blurTriggered = true)));
 
@@ -277,7 +277,7 @@ public class SelectTests : TestContextBase
     public void ComplexSelectComponentRendersCorrectly()
     {
         // Arrange & Act
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "valid-select")
             .Add(p => p.Class, "ix-warning")
             .Add(p => p.Mode, SelectMode.Single)
@@ -316,7 +316,7 @@ public class SelectTests : TestContextBase
     public void EnableTopLayerDefaultsToFalse()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select"));
 
         // Assert
@@ -328,7 +328,7 @@ public class SelectTests : TestContextBase
     public void EnableTopLayerTrueRendersAttribute()
     {
         // Arrange
-        var cut = RenderComponent<Components.Select>(parameters => parameters
+        var cut = Render<Components.Select>(parameters => parameters
             .Add(p => p.Id, "test-select")
             .Add(p => p.EnableTopLayer, true));
 

--- a/SiemensIXBlazor.Tests/SliderTests.cs
+++ b/SiemensIXBlazor.Tests/SliderTests.cs
@@ -30,7 +30,7 @@ public class SliderTests : TestContextBase
         var warningText = "Warning value";
         var validText = "Valid value";
 
-        var cut = RenderComponent<Slider>(parameters => parameters
+        var cut = Render<Slider>(parameters => parameters
             .Add(p => p.Id, id)
             .Add(p => p.Value, 42)
             .Add(p => p.HelperText, helperText)
@@ -71,7 +71,7 @@ public class SliderTests : TestContextBase
     [Fact]
     public void Slider_RendersTypedLabelSlots()
     {
-        var cut = RenderComponent<Slider>(parameters => parameters
+        var cut = Render<Slider>(parameters => parameters
             .Add(p => p.Id, "slider-slots")
             .Add(p => p.LabelStart, (RenderFragment)(builder => builder.AddContent(0, "Minimum")))
             .Add(p => p.LabelEnd, (RenderFragment)(builder => builder.AddContent(0, "Maximum"))));
@@ -85,7 +85,7 @@ public class SliderTests : TestContextBase
     {
         // Arrange
         double eventValue = 0;
-        var cut = RenderComponent<Slider>(parameters => parameters
+        var cut = Render<Slider>(parameters => parameters
             .Add(p => p.Id, "slider2")
             .Add(p => p.ValueChangeEvent, EventCallback.Factory.Create<double>(this, v => eventValue = v))
         );
@@ -130,7 +130,7 @@ public class SliderTests : TestContextBase
         var markerArray = new double[] { 0, 25, 50 };
 
         // Act
-        var cut = RenderComponent<Slider>(parameters => parameters
+        var cut = Render<Slider>(parameters => parameters
             .Add(p => p.Id, "slider-js")
             .Add(p => p.Marker, markerArray)
         );

--- a/SiemensIXBlazor.Tests/SpinnerTest.cs
+++ b/SiemensIXBlazor.Tests/SpinnerTest.cs
@@ -20,11 +20,11 @@ namespace SiemensIXBlazor.Tests
         public void SpinnerRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Spinner>(
-                ("Size", "large"),
-                ("Variant", SpinnerVariant.primary),
-                ("Style", "color: red;"),
-                ("Class", "test-class")
+            var cut = Render<Spinner>(parameters => parameters
+                .Add(p => p.Size, "large")
+                .Add(p => p.Variant, SpinnerVariant.primary)
+                .Add(p => p.Style, "color: red;")
+                .Add(p => p.Class, "test-class")
             );
 
             // Assert

--- a/SiemensIXBlazor.Tests/SplitButton/SplitButtonTest.cs
+++ b/SiemensIXBlazor.Tests/SplitButton/SplitButtonTest.cs
@@ -20,16 +20,16 @@ public class SplitButtonTests : TestContextBase
 	public void SplitButtonRendersCorrectly()
 	{
 		// Arrange
-		var cut = RenderComponent<Components.SplitButton>(
-			("Id", "testId"),
-			("Disabled", true),
-			("DisableButton", true),
-			("DisableDropdownButton", true),
-			("Icon", "test-icon"),
-			("Label", "Test Label"),
-			("SplitIcon", "context-menu"),
-			("CloseBehavior", CloseBehavior.Both),
-			("Variant", ButtonVariant.primary)
+		var cut = Render<Components.SplitButton>(parameters => parameters
+		    .Add(p => p.Id, "testId")
+		    .Add(p => p.Disabled, true)
+		    .Add(p => p.DisableButton, true)
+		    .Add(p => p.DisableDropdownButton, true)
+		    .Add(p => p.Icon, "test-icon")
+		    .Add(p => p.Label, "Test Label")
+		    .Add(p => p.SplitIcon, "context-menu")
+		    .Add(p => p.CloseBehavior, CloseBehavior.Both)
+		    .Add(p => p.Variant, ButtonVariant.primary)
 		);
 
 		// Assert
@@ -42,9 +42,9 @@ public class SplitButtonTests : TestContextBase
 	{
 		// Arrange
 		var buttonClicked = false;
-		var cut = RenderComponent<Components.SplitButton>(
-			("Id", "testId"),
-			("ButtonClickedEvent", EventCallback.Factory.Create<MouseEventArgs>(this, _ => buttonClicked = true))
+		var cut = Render<Components.SplitButton>(parameters => parameters
+		    .Add(p => p.Id, "testId")
+		    .Add(p => p.ButtonClickedEvent, EventCallback.Factory.Create<MouseEventArgs>(this, _ => buttonClicked = true))
 		);
 
 		// Act
@@ -58,7 +58,7 @@ public class SplitButtonTests : TestContextBase
 	public void EnableTopLayerDefaultsToFalse()
 	{
 		// Arrange
-		var cut = RenderComponent<Components.SplitButton>(parameters => parameters
+		var cut = Render<Components.SplitButton>(parameters => parameters
 			.Add(p => p.Id, "test-id"));
 
 		// Assert
@@ -70,7 +70,7 @@ public class SplitButtonTests : TestContextBase
 	public void EnableTopLayerTrueRendersAttribute()
 	{
 		// Arrange
-		var cut = RenderComponent<Components.SplitButton>(parameters => parameters
+		var cut = Render<Components.SplitButton>(parameters => parameters
 			.Add(p => p.Id, "test-id")
 			.Add(p => p.EnableTopLayer, true));
 

--- a/SiemensIXBlazor.Tests/TabItemTest.cs
+++ b/SiemensIXBlazor.Tests/TabItemTest.cs
@@ -21,7 +21,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void TabItemRendersOfficialDefaults()
         {
-            var component = RenderComponent<TabItem>(parameters => parameters
+            var component = Render<TabItem>(parameters => parameters
                 .Add(p => p.TabKey, "tab-1"));
 
             var tabItem = component.Find("ix-tab-item");
@@ -36,7 +36,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void TabItemRendersPublicPropertiesAndContent()
         {
-            var component = RenderComponent<TabItem>(parameters => parameters
+            var component = Render<TabItem>(parameters => parameters
                 .Add(p => p.Id, "my-tab")
                 .Add(p => p.TabKey, "tab-1")
                 .Add(p => p.Class, "custom-class")
@@ -68,7 +68,7 @@ namespace SiemensIXBlazor.Tests
         public async Task TabClickEventDeserializesTypedDetail()
         {
             TabClickDetail? clicked = null;
-            var component = RenderComponent<TabItem>(parameters => parameters
+            var component = Render<TabItem>(parameters => parameters
                 .Add(p => p.TabKey, "tab-1")
                 .Add(p => p.TabClickEvent, EventCallback.Factory.Create<TabClickDetail>(this, value => clicked = value)));
 
@@ -84,7 +84,7 @@ namespace SiemensIXBlazor.Tests
         public async Task TabCloseEventDeserializesTypedDetail()
         {
             TabClickDetail? closed = null;
-            var component = RenderComponent<TabItem>(parameters => parameters
+            var component = Render<TabItem>(parameters => parameters
                 .Add(p => p.TabKey, "tab-1")
                 .Add(p => p.TabCloseEvent, EventCallback.Factory.Create<TabClickDetail>(this, value => closed = value)));
 

--- a/SiemensIXBlazor.Tests/TabsTest.cs
+++ b/SiemensIXBlazor.Tests/TabsTest.cs
@@ -21,15 +21,15 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void TabsRendersOfficialProperties()
         {
-            var cut = RenderComponent<Tabs>(
-                ("Id", "testId"),
-                ("Layout", TabsLayout.Stretched),
-                ("Placement", TabsPlacement.Top),
-                ("Rounded", true),
-                ("ActiveTabKey", "tab-2"),
-                ("AriaLabelMoreTabs", "Show every tab"),
-                ("KeyboardNavigation", TabsKeyboardNavigation.Manual),
-                ("Small", true)
+            var cut = Render<Tabs>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Layout, TabsLayout.Stretched)
+                .Add(p => p.Placement, TabsPlacement.Top)
+                .Add(p => p.Rounded, true)
+                .Add(p => p.ActiveTabKey, "tab-2")
+                .Add(p => p.AriaLabelMoreTabs, "Show every tab")
+                .Add(p => p.KeyboardNavigation, TabsKeyboardNavigation.Manual)
+                .Add(p => p.Small, true)
             );
 
             cut.MarkupMatches("<ix-tabs id=\"testId\" layout=\"stretched\" placement=\"top\" rounded active-tab-key=\"tab-2\" aria-label-more-tabs=\"Show every tab\" keyboard-navigation=\"manual\" small></ix-tabs>");
@@ -39,7 +39,7 @@ namespace SiemensIXBlazor.Tests
         public async Task TabChangeEventUpdatesActiveKeyAndInvokesCallback()
         {
             string? changedKey = null;
-            var cut = RenderComponent<Tabs>(parameters => parameters
+            var cut = Render<Tabs>(parameters => parameters
                 .Add(p => p.Id, "testId")
                 .Add(p => p.TabChangeEvent, EventCallback.Factory.Create<string?>(this, value => changedKey = value)));
 
@@ -53,7 +53,7 @@ namespace SiemensIXBlazor.Tests
         public async Task TabCloseEventInvokesCallback()
         {
             string? closedKey = null;
-            var cut = RenderComponent<Tabs>(parameters => parameters
+            var cut = Render<Tabs>(parameters => parameters
                 .Add(p => p.Id, "testId")
                 .Add(p => p.TabCloseEvent, EventCallback.Factory.Create<string?>(this, value => closedKey = value)));
 

--- a/SiemensIXBlazor.Tests/TestContextBase.cs
+++ b/SiemensIXBlazor.Tests/TestContextBase.cs
@@ -15,7 +15,7 @@ using Moq;
 
 namespace SiemensIXBlazor.Tests;
 
-public class TestContextBase : TestContext
+public class TestContextBase : BunitContext
 {
     public TestContextBase()
     {

--- a/SiemensIXBlazor.Tests/ThemeTests.cs
+++ b/SiemensIXBlazor.Tests/ThemeTests.cs
@@ -25,7 +25,7 @@ public class ThemeTests : TestContextBase
         var themeName = "dark";
 
         // Act
-        var cut = RenderComponent<Theme>();
+        var cut = Render<Theme>((Action<Bunit.ComponentParameterCollectionBuilder<Theme>>)(_ => { }));
         await cut.Instance.SetTheme(themeName);
 
         // Assert
@@ -49,7 +49,7 @@ public class ThemeTests : TestContextBase
         Services.AddSingleton<IJSRuntime>(jsRuntimeMock.Object);
 
         // Act
-        var cut = RenderComponent<Theme>();
+        var cut = Render<Theme>((Action<Bunit.ComponentParameterCollectionBuilder<Theme>>)(_ => { }));
         await cut.Instance.ToggleTheme();
 
         // Assert
@@ -70,7 +70,7 @@ public class ThemeTests : TestContextBase
         var useSystemTheme = true;
 
         // Act
-        var cut = RenderComponent<Theme>();
+        var cut = Render<Theme>((Action<Bunit.ComponentParameterCollectionBuilder<Theme>>)(_ => { }));
         await cut.Instance.ToggleSystemTheme(useSystemTheme);
 
         // Assert

--- a/SiemensIXBlazor.Tests/TileTest.cs
+++ b/SiemensIXBlazor.Tests/TileTest.cs
@@ -21,9 +21,9 @@ namespace SiemensIXBlazor.Tests
         public void TileRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Tile>(
-                ("Size", TileSize.Medium),
-                ("ChildContent", (RenderFragment)(builder =>
+            var cut = Render<Tile>(parameters => parameters
+                .Add(p => p.Size, TileSize.Medium)
+                .Add(p => p.ChildContent, (RenderFragment)(builder =>
                 {
                     builder.AddMarkupContent(0, "<div>Test child content</div>");
                 }))

--- a/SiemensIXBlazor.Tests/TimeInputTest.cs
+++ b/SiemensIXBlazor.Tests/TimeInputTest.cs
@@ -20,7 +20,7 @@ public class TimeInputTest : TestContextBase
     public void EnableTopLayerDefaultsToFalse()
     {
         // Arrange
-        var cut = RenderComponent<TimeInput>(parameters => parameters
+        var cut = Render<TimeInput>(parameters => parameters
             .Add(p => p.Id, "test-id"));
 
         // Assert
@@ -32,7 +32,7 @@ public class TimeInputTest : TestContextBase
     public void EnableTopLayerTrueRendersAttribute()
     {
         // Arrange
-        var cut = RenderComponent<TimeInput>(parameters => parameters
+        var cut = Render<TimeInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.EnableTopLayer, true));
 
@@ -46,7 +46,7 @@ public class TimeInputTest : TestContextBase
     {
         // Arrange
         var received = string.Empty;
-        var cut = RenderComponent<TimeInput>(parameters => parameters
+        var cut = Render<TimeInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 
@@ -62,7 +62,7 @@ public class TimeInputTest : TestContextBase
     {
         // Arrange
         var received = "initial";
-        var cut = RenderComponent<TimeInput>(parameters => parameters
+        var cut = Render<TimeInput>(parameters => parameters
             .Add(p => p.Id, "test-id")
             .Add(p => p.ChangeEvent, EventCallback.Factory.Create<string>(this, (string val) => received = val)));
 
@@ -76,7 +76,7 @@ public class TimeInputTest : TestContextBase
     [Fact]
     public void OfficialDefaultsAreExposed()
     {
-        var cut = RenderComponent<TimeInput>(parameters => parameters.Add(p => p.Id, "time-input"));
+        var cut = Render<TimeInput>(parameters => parameters.Add(p => p.Id, "time-input"));
 
         Assert.Equal("TT", cut.Instance.Format);
         Assert.Equal(100, cut.Instance.MillisecondInterval);

--- a/SiemensIXBlazor.Tests/TimePickerTests.cs
+++ b/SiemensIXBlazor.Tests/TimePickerTests.cs
@@ -19,7 +19,7 @@ public class TimePickerTests : TestContextBase
     [Fact]
     public void OfficialDefaultsAreRendered()
     {
-        var cut = RenderComponent<TimePicker>(parameters => parameters.Add(p => p.Id, "time-picker"));
+        var cut = Render<TimePicker>(parameters => parameters.Add(p => p.Id, "time-picker"));
         var picker = cut.Find("ix-time-picker");
 
         Assert.Equal("rounded", picker.GetAttribute("corners"));
@@ -36,7 +36,7 @@ public class TimePickerTests : TestContextBase
     [InlineData(TimePickerCorners.Straight, "straight")]
     public void CornersRenderCorrectly(TimePickerCorners corners, string expected)
     {
-        var cut = RenderComponent<TimePicker>(parameters => parameters
+        var cut = Render<TimePicker>(parameters => parameters
             .Add(p => p.Id, "time-picker")
             .Add(p => p.Corners, corners));
 
@@ -48,7 +48,7 @@ public class TimePickerTests : TestContextBase
     {
         string? selected = null;
         string? changed = null;
-        var cut = RenderComponent<TimePicker>(parameters => parameters
+        var cut = Render<TimePicker>(parameters => parameters
             .Add(p => p.Id, "time-picker")
             .Add(p => p.TimeSelectEvent, EventCallback.Factory.Create<string>(this, value => selected = value))
             .Add(p => p.TimeChangeEvent, EventCallback.Factory.Create<string>(this, value => changed = value)));

--- a/SiemensIXBlazor.Tests/ToastTests.cs
+++ b/SiemensIXBlazor.Tests/ToastTests.cs
@@ -25,7 +25,7 @@ public class ToastTests : TestContextBase
     [Fact]
     public void ToastContainer_RendersOfficialDefaults()
     {
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container"));
 
         var container = cut.Find("ix-toast-container");
@@ -36,7 +36,7 @@ public class ToastTests : TestContextBase
     [Fact]
     public void ToastContainer_RendersTopRightPositionAndAttributes()
     {
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container")
             .Add(p => p.Position, ToastPosition.TopRight)
             .AddUnmatched("role", "region")
@@ -53,7 +53,7 @@ public class ToastTests : TestContextBase
     [Fact]
     public void Toast_RendersOfficialPropertiesAndSlots()
     {
-        var cut = RenderComponent<Toast>(parameters => parameters
+        var cut = Render<Toast>(parameters => parameters
             .Add(p => p.Id, "toast")
             .Add(p => p.Type, ToastType.Success)
             .Add(p => p.ToastTitle, "Saved")
@@ -83,7 +83,7 @@ public class ToastTests : TestContextBase
     [Fact]
     public void Toast_OmitsFalseBooleanProperties()
     {
-        var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
+        var cut = Render<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
 
         var toast = cut.Find("ix-toast");
         Assert.Null(toast.GetAttribute("prevent-auto-close"));
@@ -94,7 +94,7 @@ public class ToastTests : TestContextBase
     public async Task Toast_CloseToastInvokesCallback()
     {
         var closed = false;
-        var cut = RenderComponent<Toast>(parameters => parameters
+        var cut = Render<Toast>(parameters => parameters
             .Add(p => p.Id, "toast")
             .Add(p => p.CloseToastEvent, EventCallback.Factory.Create(this, () => closed = true)));
 
@@ -110,7 +110,7 @@ public class ToastTests : TestContextBase
         module.Setup(m => m.InvokeAsync<bool>("isToastPaused", It.IsAny<object[]>()))
             .Returns(new ValueTask<bool>(true));
 
-        var cut = RenderComponent<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
+        var cut = Render<Toast>(parameters => parameters.Add(p => p.Id, "toast"));
 
         await cut.Instance.PauseAsync();
         await cut.Instance.ResumeAsync();
@@ -130,7 +130,7 @@ public class ToastTests : TestContextBase
         module.Setup(m => m.InvokeAsync<bool>("isPaused", It.IsAny<object[]>()))
             .Returns(new ValueTask<bool>(true));
 
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container"));
         var result = await cut.Instance.ShowToast(new ToastConfig
         {
@@ -163,7 +163,7 @@ public class ToastTests : TestContextBase
         module.Setup(m => m.InvokeAsync<string>("showToast", It.IsAny<object[]>()))
             .Returns(new ValueTask<string>("toast-1"));
 
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container"));
         var result = await cut.Instance.ShowToast(new ToastConfig { Message = "Message" });
         JsonElement? received = null;
@@ -178,7 +178,7 @@ public class ToastTests : TestContextBase
     [Fact]
     public async Task ToastContainer_RejectsNullConfiguration()
     {
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container"));
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => cut.Instance.ShowToast(null!));
@@ -191,7 +191,7 @@ public class ToastTests : TestContextBase
         module.Setup(m => m.InvokeAsync<string>("showToast", It.IsAny<object[]>()))
             .Returns(new ValueTask<string>("toast-1"));
 
-        var cut = RenderComponent<ToastContainer>(parameters => parameters
+        var cut = Render<ToastContainer>(parameters => parameters
             .Add(p => p.Id, "toast-container"));
         await cut.Instance.ShowToast(new ToastConfig { Message = "Message" });
 

--- a/SiemensIXBlazor.Tests/ToggleButton/IconToggleButtonTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleButton/IconToggleButtonTest.cs
@@ -21,17 +21,17 @@ namespace SiemensIXBlazor.Tests.ToggleButton
         public void IconToggleButtonRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<IconToggleButton>(
-                ("Id", "testId"),
-                ("Disabled", true),
-                ("Ghost", true),
-                ("Icon", "test-icon"),
-                ("Loading", true),
-                ("Outline", true),
-                ("Pressed", true),
-                ("Size", IconButtonSize._16),
-                ("Variant", ButtonVariant.subtle_secondary),
-                ("Oval", true)
+            var cut = Render<IconToggleButton>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Disabled, true)
+                .Add(p => p.Ghost, true)
+                .Add(p => p.Icon, "test-icon")
+                .Add(p => p.Loading, true)
+                .Add(p => p.Outline, true)
+                .Add(p => p.Pressed, true)
+                .Add(p => p.Size, IconButtonSize._16)
+                .Add(p => p.Variant, ButtonVariant.subtle_secondary)
+                .Add(p => p.Oval, true)
             );
 
             // Assert
@@ -43,9 +43,9 @@ namespace SiemensIXBlazor.Tests.ToggleButton
         {
             // Arrange
             var pressedChanged = false;
-            var cut = RenderComponent<IconToggleButton>(
-                ("Id", "iconToggleButton"),
-                ("PressedChangeEvent", EventCallback.Factory.Create<bool>(this, newValue => { pressedChanged = true; }))
+            var cut = Render<IconToggleButton>(parameters => parameters
+                .Add(p => p.Id, "iconToggleButton")
+                .Add(p => p.PressedChangeEvent, EventCallback.Factory.Create<bool>(this, newValue => { pressedChanged = true; }))
             );
 
             // Act

--- a/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleButton/ToggleButtonTest.cs
@@ -20,14 +20,14 @@ namespace SiemensIXBlazor.Tests.ToggleButton
         public void ToggleButtonRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Components.ToggleButton.ToggleButton>(
-                ("Id", "testId"),
-                ("Disabled", true),
-                ("Icon", "test-icon"),
-                ("IconRight", "test-icon-right"),
-                ("Loading", true),
-                ("Pressed", true),
-                ("Variant", ToggleButtonVariant.subtle_secondary)
+            var cut = Render<Components.ToggleButton.ToggleButton>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Disabled, true)
+                .Add(p => p.Icon, "test-icon")
+                .Add(p => p.IconRight, "test-icon-right")
+                .Add(p => p.Loading, true)
+                .Add(p => p.Pressed, true)
+                .Add(p => p.Variant, ToggleButtonVariant.subtle_secondary)
             );
 
             // Assert
@@ -39,9 +39,9 @@ namespace SiemensIXBlazor.Tests.ToggleButton
         {
             // Arrange
             var pressedChanged = false;
-            var cut = RenderComponent<Components.ToggleButton.ToggleButton>(
-                ("Id", "toggleButton"),
-                ("PressedChangeEvent", EventCallback.Factory.Create<bool>(this, newValue => { pressedChanged = true; }))
+            var cut = Render<Components.ToggleButton.ToggleButton>(parameters => parameters
+                .Add(p => p.Id, "toggleButton")
+                .Add(p => p.PressedChangeEvent, EventCallback.Factory.Create<bool>(this, newValue => { pressedChanged = true; }))
             );
 
             // Act

--- a/SiemensIXBlazor.Tests/ToggleTest.cs
+++ b/SiemensIXBlazor.Tests/ToggleTest.cs
@@ -20,15 +20,15 @@ namespace SiemensIXBlazor.Tests
         public void ToggleRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Toggle>(
-                ("Id", "testId"),
-                ("Checked", true),
-                ("Disabled", true),
-                ("HideText", true),
-                ("Indeterminate", true),
-                ("TextIndeterminate", "Mixed"),
-                ("TextOff", "Off"),
-                ("TextOn", "On")
+            var cut = Render<Toggle>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Checked, true)
+                .Add(p => p.Disabled, true)
+                .Add(p => p.HideText, true)
+                .Add(p => p.Indeterminate, true)
+                .Add(p => p.TextIndeterminate, "Mixed")
+                .Add(p => p.TextOff, "Off")
+                .Add(p => p.TextOn, "On")
             );
 
             // Assert
@@ -40,9 +40,9 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             var checkedChanged = false;
-            var cut = RenderComponent<Toggle>(
-                ("Id", "testId"),
-                ("CheckedChangeEvent", EventCallback.Factory.Create(this, (bool value) => checkedChanged = true))
+            var cut = Render<Toggle>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.CheckedChangeEvent, EventCallback.Factory.Create(this, (bool value) => checkedChanged = true))
             );
 
             // Act

--- a/SiemensIXBlazor.Tests/TooltipTest.cs
+++ b/SiemensIXBlazor.Tests/TooltipTest.cs
@@ -22,12 +22,12 @@ namespace SiemensIXBlazor.Tests
         public void TooltipRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Tooltip>(
-                ("Id", "tooltipId"),
-                ("TitleContent", "Test Tooltip"),
-                ("Interactive", true),
-                ("Placement", TooltipVariant.bottom),
-                ("For", "testElement")
+            var cut = Render<Tooltip>(parameters => parameters
+                .Add(p => p.Id, "tooltipId")
+                .Add(p => p.TitleContent, "Test Tooltip")
+                .Add(p => p.Interactive, true)
+                .Add(p => p.Placement, TooltipVariant.bottom)
+                .Add(p => p.For, "testElement")
             );
 
             // Assert

--- a/SiemensIXBlazor.Tests/TreeTests.cs
+++ b/SiemensIXBlazor.Tests/TreeTests.cs
@@ -26,7 +26,7 @@ public class TreeTests : TestContextBase
             ["node"] = new() { Id = "node", Data = new TreeData { Name = "Node" } }
         };
 
-        var cut = RenderComponent<Tree>(parameters => parameters
+        var cut = Render<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-id")
             .Add(p => p.Root, "root")
             .Add(p => p.Model, model)
@@ -42,13 +42,13 @@ public class TreeTests : TestContextBase
     [Fact]
     public async Task ContextChanged_ShouldDeserializeDisabledState()
     {
-        var cut = RenderComponent<Tree>(parameters => parameters
+        var cut = Render<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-id")
             .Add(p => p.ContextChangedEvent, EventCallback.Factory.Create<Dictionary<string, TreeContextNode>>(
                 this, _ => { })));
 
         Dictionary<string, TreeContextNode>? receivedContext = null;
-        cut.SetParametersAndRender(parameters => parameters
+        cut.Render(parameters => parameters
             .Add(p => p.ContextChangedEvent, EventCallback.Factory.Create<Dictionary<string, TreeContextNode>>(
                 this, context => receivedContext = context)));
 
@@ -63,11 +63,11 @@ public class TreeTests : TestContextBase
     [Fact]
     public async Task NodeToggled_ShouldExposeOfficialIsExpandedProperty()
     {
-        var cut = RenderComponent<Tree>(parameters => parameters
+        var cut = Render<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-id"));
         TreeNodeToggledEventResult? result = null;
 
-        cut.SetParametersAndRender(parameters => parameters
+        cut.Render(parameters => parameters
             .Add(p => p.NodeToggledEvent, EventCallback.Factory.Create<TreeNodeToggledEventResult>(
                 this, value => result = value)));
 
@@ -82,7 +82,7 @@ public class TreeTests : TestContextBase
     [Fact]
     public async Task TreeMethods_ShouldAcceptOfficialMethodShapes()
     {
-        var cut = RenderComponent<Tree>(parameters => parameters
+        var cut = Render<Tree>(parameters => parameters
             .Add(p => p.Id, "tree-methods"));
 
         await cut.Instance.MarkItemsAsDirty("item1", "item2");
@@ -104,7 +104,7 @@ public class TreeTests : TestContextBase
         var toggled = false;
         var clicked = false;
 
-        var cut = RenderComponent<TreeItem>(parameters => parameters
+        var cut = Render<TreeItem>(parameters => parameters
             .Add(p => p.Text, "Node")
             .Add(p => p.HasChildren, true)
             .Add(p => p.Disabled, true)

--- a/SiemensIXBlazor.Tests/TypographyTest.cs
+++ b/SiemensIXBlazor.Tests/TypographyTest.cs
@@ -19,13 +19,13 @@ public class TypographyTest : TestContextBase
 	public void TypographyRendersCorrectly()
 	{
 		// Arrange
-		var cut = RenderComponent<Typography>(
-			("Id", "testId"),
-			("Format", TypographyFormat.Body_Xs),
-			("Bold", true),
-			("TextColor", TypographyColor.Alarm),
-			("TextDecoration", TextDecoration.Line_Through),
-			("ChildContent", (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
+		var cut = Render<Typography>(parameters => parameters
+		    .Add(p => p.Id, "testId")
+		    .Add(p => p.Format, TypographyFormat.Body_Xs)
+		    .Add(p => p.Bold, true)
+		    .Add(p => p.TextColor, TypographyColor.Alarm)
+		    .Add(p => p.TextDecoration, TextDecoration.Line_Through)
+		    .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddMarkupContent(0, "Test content")))
 		);
 
 		// Assert

--- a/SiemensIXBlazor.Tests/UploadTest.cs
+++ b/SiemensIXBlazor.Tests/UploadTest.cs
@@ -23,20 +23,20 @@ namespace SiemensIXBlazor.Tests
         public void UploadRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<Upload>(
-                ("Id", "testId"),
-                ("Accept", "image/*"),
-                ("Disabled", true),
-                ("I18nUploadDisabled", "File upload currently not possible."),
-                ("I18nUploadFile", "Upload file…"),
-                ("LoadingText", "Checking files…"),
-                ("Multiline", true),
-                ("Multiple", true),
-                ("DirectoryUpload", true),
-                ("State", UploadFileState.UPLOAD_FAILED),
-                ("SelectFileText", "+ Drag files here or…"),
-                ("UploadFailedText", "Upload failed. Please try again."),
-                ("UploadSuccessText", "Upload successful")
+            var cut = Render<Upload>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Accept, "image/*")
+                .Add(p => p.Disabled, true)
+                .Add(p => p.I18nUploadDisabled, "File upload currently not possible.")
+                .Add(p => p.I18nUploadFile, "Upload file…")
+                .Add(p => p.LoadingText, "Checking files…")
+                .Add(p => p.Multiline, true)
+                .Add(p => p.Multiple, true)
+                .Add(p => p.DirectoryUpload, true)
+                .Add(p => p.State, UploadFileState.UPLOAD_FAILED)
+                .Add(p => p.SelectFileText, "+ Drag files here or…")
+                .Add(p => p.UploadFailedText, "Upload failed. Please try again.")
+                .Add(p => p.UploadSuccessText, "Upload successful")
             );
 
             // Assert
@@ -46,7 +46,7 @@ namespace SiemensIXBlazor.Tests
         [Fact]
         public void DirectoryUploadUsesOfficialDefaultState()
         {
-            var cut = RenderComponent<Upload>(parameters => parameters
+            var cut = Render<Upload>(parameters => parameters
                 .Add(p => p.Id, "folder-upload")
                 .Add(p => p.DirectoryUpload, true));
 
@@ -58,7 +58,7 @@ namespace SiemensIXBlazor.Tests
         {
             // Arrange
             IXFile? changedFile = null;
-            var cut = RenderComponent<Upload>(parameters => parameters
+            var cut = Render<Upload>(parameters => parameters
                 .Add(p => p.Id, "upload")
                 .Add(p => p.FileChangedEvent, EventCallback.Factory.Create<List<IXFile>>(this, newValue => { changedFile = newValue.Single(); }))
             );

--- a/SiemensIXBlazor.Tests/ValidationTooltipTest.cs
+++ b/SiemensIXBlazor.Tests/ValidationTooltipTest.cs
@@ -27,7 +27,7 @@ public class ValidationTooltipTests : TestContextBase
 		ValidationTooltipPlacement placement = ValidationTooltipPlacement.Top;
 
 		// Act
-		var cut = RenderComponent<ValidationTooltip>(parameters => parameters
+		var cut = Render<ValidationTooltip>(parameters => parameters
 				.Add(p => p.Id, id)
 				.Add(p => p.Style, style)
 				.Add(p => p.Class, cssClass)
@@ -52,7 +52,7 @@ public class ValidationTooltipTests : TestContextBase
 		string childContent = $@"<label for=""validationCustom01"">Example input</label><input id=""validationCustom01"" value="""" required minlength=""4"" />";
 
 		// Act
-		var cut = RenderComponent<ValidationTooltip>(parameters => parameters
+		var cut = Render<ValidationTooltip>(parameters => parameters
 			.AddChildContent(childContent)
 		);
 

--- a/SiemensIXBlazor.Tests/Workflow/WorkflowStepTest.cs
+++ b/SiemensIXBlazor.Tests/Workflow/WorkflowStepTest.cs
@@ -21,13 +21,13 @@ namespace SiemensIXBlazor.Tests.Workflow
         public void WorkflowStepRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<WorkflowStep>(
-                ("Clickable", true),
-                ("Disabled", true),
-                ("Position", WorkflowPosition.First),
-                ("Selected", true),
-                ("Status", WorkflowStatus.Open),
-                ("Vertical", true)
+            var cut = Render<WorkflowStep>(parameters => parameters
+                .Add(p => p.Clickable, true)
+                .Add(p => p.Disabled, true)
+                .Add(p => p.Position, WorkflowPosition.First)
+                .Add(p => p.Selected, true)
+                .Add(p => p.Status, WorkflowStatus.Open)
+                .Add(p => p.Vertical, true)
             );
 
             // Assert
@@ -37,7 +37,7 @@ namespace SiemensIXBlazor.Tests.Workflow
         [Fact]
         public void CustomIconRendersInCustomIconSlot()
         {
-            var cut = RenderComponent<WorkflowStep>(parameters => parameters
+            var cut = Render<WorkflowStep>(parameters => parameters
                 .Add(p => p.CustomIcon, (RenderFragment)(builder => builder.AddMarkupContent(0, "<ix-icon name=\"star\"></ix-icon>")))
                 .Add(p => p.ChildContent, (RenderFragment)(builder => builder.AddContent(0, "Step"))));
 

--- a/SiemensIXBlazor.Tests/Workflow/WorkflowStepsTest.cs
+++ b/SiemensIXBlazor.Tests/Workflow/WorkflowStepsTest.cs
@@ -20,11 +20,11 @@ namespace SiemensIXBlazor.Tests.Workflow
         public void WorkflowStepsRendersCorrectly()
         {
             // Arrange
-            var cut = RenderComponent<WorkflowSteps>(
-                ("Id", "testId"),
-                ("Clickable", true),
-                ("SelectedIndex", 1),
-                ("Vertical", true)
+            var cut = Render<WorkflowSteps>(parameters => parameters
+                .Add(p => p.Id, "testId")
+                .Add(p => p.Clickable, true)
+                .Add(p => p.SelectedIndex, 1)
+                .Add(p => p.Vertical, true)
             );
 
             // Assert
@@ -36,9 +36,9 @@ namespace SiemensIXBlazor.Tests.Workflow
         {
             // Arrange
             var stepSelected = false;
-            var cut = RenderComponent<WorkflowSteps>(
-                ("Id", "workflowSteps"),
-                ("StepSelectedEvent", EventCallback.Factory.Create<int>(this, newValue => { stepSelected = true; }))
+            var cut = Render<WorkflowSteps>(parameters => parameters
+                .Add(p => p.Id, "workflowSteps")
+                .Add(p => p.StepSelectedEvent, EventCallback.Factory.Create<int>(this, newValue => { stepSelected = true; }))
             );
 
             // Act

--- a/SiemensIXBlazor/Components/Drawer/Drawer.razor.cs
+++ b/SiemensIXBlazor/Components/Drawer/Drawer.razor.cs
@@ -28,11 +28,11 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public int MaxWidth { get; set; } = 28;
         [Parameter]
-        public static int MinWidth { get; set; } = 16;
+        public int MinWidth { get; set; } = 16;
         [Parameter]
         public bool Show { get; set; } = false;
         [Parameter]
-        public int Width { get; set; } = MinWidth;
+        public int Width { get; set; } = 16;
         [Parameter]
         public EventCallback ClosedEvent { get; set; }
         [Parameter]

--- a/SiemensIXBlazor/SiemensIXBlazor_NpmJS/package-lock.json
+++ b/SiemensIXBlazor/SiemensIXBlazor_NpmJS/package-lock.json
@@ -17,14 +17,14 @@
         "echarts": "^5.5.1"
       },
       "devDependencies": {
-        "webpack": "^5.105.2",
-        "webpack-cli": "^6.0.1"
+        "webpack": "^5.109.2",
+        "webpack-cli": "^7.2.2"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -150,32 +150,10 @@
         "pnpm": ">=10.x.x"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -187,13 +165,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -357,53 +335,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -419,9 +350,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -429,19 +360,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/ag-charts-types": {
@@ -460,9 +378,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -617,13 +535,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -664,14 +575,14 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -691,9 +602,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -772,9 +683,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -787,16 +698,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -831,13 +732,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -960,13 +854,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -982,20 +869,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -1028,26 +901,74 @@
       "license": "MIT"
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/neo-async": {
@@ -1324,9 +1245,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1338,9 +1259,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1356,40 +1277,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -1397,9 +1284,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1435,13 +1322,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -1449,37 +1335,32 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -1498,22 +1379,17 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
+      "integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"
@@ -1522,16 +1398,30 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },
@@ -1541,13 +1431,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-merge": {
@@ -1566,9 +1456,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/SiemensIXBlazor/SiemensIXBlazor_NpmJS/package.json
+++ b/SiemensIXBlazor/SiemensIXBlazor_NpmJS/package.json
@@ -18,7 +18,7 @@
     "echarts": "^5.5.1"
   },
   "devDependencies": {
-    "webpack": "^5.105.2",
-    "webpack-cli": "^6.0.1"
+    "webpack": "^5.109.2",
+    "webpack-cli": "^7.2.2"
   }
 }


### PR DESCRIPTION
## 💡 What is the current behavior?

The test suite uses obsolete bUnit 1.x APIs that are incompatible with bUnit 2.9.0. Some tests also assign component parameters directly, producing analyzer warnings, and `Drawer.MinWidth` is incorrectly declared as a static component parameter.

GitHub Issue Number: #241

## 🆕 What is the new behavior?

- Migrate the test suite to bUnit 2 APIs and remove parameter assignment warnings.
- Correct `Drawer.MinWidth` to use the proper instance parameter behavior.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)