### PR TITLE
style(csharp): normalize acronym casing

### DIFF
--- a/SiemensIXBlazor.Tests/CardListTests.cs
+++ b/SiemensIXBlazor.Tests/CardListTests.cs
@@ -23,8 +23,8 @@ namespace SiemensIXBlazor.Tests
 			{
 				parameters.Add(p => p.Id, "testId");
 				parameters.Add(p => p.Collapse, true);
-				parameters.Add(p => p.I18NMoreCards, "testMoreCards");
-				parameters.Add(p => p.I18NShowAll, "testShowAll");
+				parameters.Add(p => p.I18nMoreCards, "testMoreCards");
+				parameters.Add(p => p.I18nShowAll, "testShowAll");
 				parameters.Add(p => p.Label, "testLabel");
 				parameters.Add(p => p.ListStyle, Enums.CardList.CardListStyle.Stack);
 				parameters.Add(p => p.ShowAllCount, 1);

--- a/SiemensIXBlazor.Tests/ToastTests.cs
+++ b/SiemensIXBlazor.Tests/ToastTests.cs
@@ -223,7 +223,7 @@ public class ToastTests : TestContextBase
         Assert.DoesNotContain("position", json);
     }
 
-    private (Mock<IJSRuntime> JsRuntime, Mock<IJSObjectReference> Module) AddJsModule()
+    private (Mock<IJSRuntime> JSRuntime, Mock<IJSObjectReference> Module) AddJsModule()
     {
         var jsRuntime = new Mock<IJSRuntime>();
         var module = new Mock<IJSObjectReference>();

--- a/SiemensIXBlazor/Components/CardList/CardList.razor
+++ b/SiemensIXBlazor/Components/CardList/CardList.razor
@@ -18,7 +18,7 @@
 <ix-card-list @attributes="UserAttributes" class="@Class" style="@Style" id="@Id" label="@Label"
 			  show-all-count="@ShowAllCount" list-style="@(EnumParser<CardListStyle>.EnumToString(ListStyle))"
 			  aria-label-expand-button="@AriaLabelExpandButton"
-			  collapse="@Collapse" i18n-more-cards="@I18NMoreCards" i18n-show-all="@I18NShowAll"
+			  collapse="@Collapse" i18n-more-cards="@I18nMoreCards" i18n-show-all="@I18nShowAll"
 			  suppress-overflow-handling="@SuppressOverflowHandling" hide-show-all="@HideShowAll">
 	@ChildContent
 </ix-card-list>

--- a/SiemensIXBlazor/Components/CardList/CardList.razor.cs
+++ b/SiemensIXBlazor/Components/CardList/CardList.razor.cs
@@ -26,9 +26,9 @@ namespace SiemensIXBlazor.Components
         [Parameter]
 		public bool Collapse { get; set; } = false;
 		[Parameter]
-		public string I18NMoreCards { get; set; } = "There are more cards available";
+		public string I18nMoreCards { get; set; } = "There are more cards available";
 		[Parameter]
-		public string I18NShowAll { get; set; } = "Show all";
+		public string I18nShowAll { get; set; } = "Show all";
 		[Parameter]
 		public string? Label { get; set; }
 		[Parameter]

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor
@@ -12,7 +12,7 @@
 @using SiemensIXBlazor.Enums.Button
 @using SiemensIXBlazor.Helpers
 @namespace SiemensIXBlazor.Components
-@inject IJSRuntime JsRuntime
+@inject IJSRuntime JSRuntime
 @inherits IXBaseComponent
 
 <ix-date-dropdown @attributes="UserAttributes"

--- a/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
+++ b/SiemensIXBlazor/Components/DateDropdown/DateDropdown.razor.cs
@@ -43,7 +43,7 @@ public partial class DateDropdown
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        _interop ??= new BaseInterop(JsRuntime);
+        _interop ??= new BaseInterop(JSRuntime);
 
         var optionsJson = JsonSerializer.Serialize(DateRangeOptions);
         if (_dateRangeOptionsJson != optionsJson)


### PR DESCRIPTION
## 💡 What is the current behavior?

CardList uses inconsistent `I18n` parameter casing, and JavaScript runtime references use mixed `JSRuntime` and `JsRuntime` naming across components and tests.

## 🆕 What is the new behavior?

- Normalize CardList parameters to the common `I18n` convention.
- Standardize `JSRuntime` naming and update related bindings and tests.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)