### PR TITLE
refactor(tabs): remove unreachable `InitialComponent` interop

### DIFF
--- a/SiemensIXBlazor/Interops/TabsInterop.cs
+++ b/SiemensIXBlazor/Interops/TabsInterop.cs
@@ -21,12 +21,6 @@ namespace SiemensIXBlazor.Interops
                 "import", $"./_content/Siemens.IX.Blazor/js/siemens-ix/interops/tabsInterop.js").AsTask());
         }
 
-        public async Task InitialComponent(string id)
-        {
-            var module = await moduleTask.Value;
-            await module.InvokeAsync<string>("initialTable", id);
-        }
-
         public async Task SubscribeEvents(object classObject, string id, string eventName, string methodName)
         {
             var module = await moduleTask.Value;

--- a/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/tabsInterop.js
+++ b/SiemensIXBlazor/wwwroot/js/siemens-ix/interops/tabsInterop.js
@@ -7,41 +7,6 @@
 // LICENSE file in the root directory of this source tree.
 //  -----------------------------------------------------------------------
 
-export const initializeTabs = async (id) => {
-  // Ensure that the custom element 'ix-tabs' is defined before proceeding
-  await window.customElements.whenDefined("ix-tabs");
-
-  const tabsElement = document.getElementById(id);
-  if (!tabsElement) {
-    console.error(`Element with ID ${id} not found.`);
-    return;
-  }
-
-  const tabs = tabsElement.querySelectorAll("ix-tab-item[data-tab-id]");
-  if (tabs.length === 0) {
-    console.warn(`No tabs found within element with ID ${id}.`);
-    return;
-  }
-
-  // Register tab click listeners
-  tabs.forEach(registerTabClickListener);
-
-  function registerTabClickListener(tab) {
-    tab.addEventListener("click", () => handleTabClick(tab, tabsElement));
-  }
-
-  function handleTabClick(clickedTab, containerElement) {
-    const contentList =
-      containerElement.parentElement.querySelectorAll("[data-tab-content]");
-    contentList.forEach((content) => {
-      content.classList.toggle(
-        "show",
-        content.dataset.tabContent === clickedTab.dataset.tabId
-      );
-    });
-  }
-};
-
 export const subscribeEvents = (caller, id, eventName, functionName) => {
   const element = document.getElementById(id);
   if (!element) {


### PR DESCRIPTION
## 💡 What is the current behavior?

`InitialComponent` invoked the JS export "initialTable", but `tabsInterop.js` exports `initializeTabs` -- the name diverged in `a7ad611` and was never realigned. `52bc84c` dropped the only call site, so the method has been dead code since. Its JS counterpart is likewise unreferenced: the data-tab-id/data-tab-content contract it implements appears nowhere, as tab content switching is driven by `SelectedChangeEvent` on the Blazor side.

## 🆕 What is the new behavior?

Remove both halves so the broken invoke cannot be revived by accident.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated
- [x] 🧪 Unit tests were added/updated and pass (`dotnet test`)
- [x] 🏗️ Successful compilation (`dotnet build`, changes pushed)

## 👨‍💻 Help & support

Nope. I'm fine.
